### PR TITLE
Let container_t manage fusefs_t socket files and FIFOs

### DIFF
--- a/container.te
+++ b/container.te
@@ -460,6 +460,8 @@ tunable_policy(`virt_use_samba',`
 fs_manage_fusefs_dirs(container_runtime_t)
 fs_manage_fusefs_files(container_runtime_t)
 fs_manage_fusefs_symlinks(container_runtime_t)
+fs_manage_fusefs_named_pipes(container_runtime_t)
+fs_manage_fusefs_named_sockets(container_runtime_t)
 fs_mount_fusefs(container_runtime_t)
 fs_unmount_fusefs(container_runtime_t)
 fs_exec_fusefs_files(container_runtime_t)
@@ -827,6 +829,8 @@ tunable_policy(`container_manage_cgroup',`
 fs_manage_fusefs_dirs(container_t)
 fs_manage_fusefs_files(container_t)
 fs_manage_fusefs_symlinks(container_t)
+fs_manage_fusefs_named_pipes(container_t)
+fs_manage_fusefs_named_sockets(container_t)
 fs_exec_fusefs_files(container_t)
 
 tunable_policy(`virt_sandbox_use_fusefs',`


### PR DESCRIPTION
Fixes e.g. AVC generated by PostgreSQL:
type=AVC msg=audit(1549290972.450:2851): avc:  denied  { create }
for  pid=9141 comm="postgres" name=".s.PGSQL.54321"
scontext=system_u:system_r:container_t:s0:c230,c677
tcontext=system_u:object_r:fusefs_t:s0 tclass=sock_file
permissive=0

Depends-on: fedora-selinux/selinux-policy#247