### PR TITLE
Add containerd paths

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -3,6 +3,7 @@
 /usr/libexec/docker/.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/libexec/docker/docker.*	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/docker.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/containerd.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/lxc-.*			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/lxd-.*			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/lxc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
@@ -14,6 +15,7 @@
 /usr/local/bin/podman		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/runc		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/sbin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/container[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/sbin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
@@ -31,6 +33,7 @@
 
 /usr/lib/systemd/system/docker.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/lib/systemd/system/lxd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
+/usr/lib/systemd/system/containerd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 
 /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/docker-latest(/.*)?		gen_context(system_u:object_r:container_config_t,s0)


### PR DESCRIPTION
Now that containerd is packaged as a standalone project, include the paths where
it is installed for SELinux.

Note that currently, until runc reaches 1.0, the containerd packaging includes
runc, and it is packaged in `/usr/sbin`, so add this path too.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>