### PR TITLE
Dontaudit containers to request limits and signal state from container engine.

### DIFF
--- a/container.te
+++ b/container.te
@@ -33,6 +33,7 @@ attribute container_domain;
 attribute container_net_domain;
 allow container_runtime_t container_domain:process { dyntransition transition };
 allow container_runtime_t container_domain:process2 { nnp_transition nosuid_transition };
+dontaudit container_runtime_t container_domain:process { noatsecure rlimitinh siginh };
 
 type spc_t, container_domain;
 domain_type(spc_t)


### PR DESCRIPTION
I see these denials if create SELinux policy using udica tool. It should be dontaudited. 

Found by: @janzarsky

PTAL: @rhatdan 