### PR TITLE
Allow containers to use onloadfs files

### DIFF
--- a/container.te
+++ b/container.te
@@ -681,6 +681,7 @@ allow container_domain self:unix_dgram_socket create_socket_perms;
 allow container_domain self:unix_stream_socket create_stream_socket_perms;
 dontaudit container_domain self:capability2  block_suspend ;
 allow container_domain self:unix_stream_socket { sendto create_stream_socket_perms };
+fs_rw_onload_sockets(container_domain)
 
 manage_files_pattern(container_domain, container_file_t, container_file_t)
 exec_files_pattern(container_domain, container_file_t, container_file_t)


### PR DESCRIPTION
This PR allows containers to use [Onload](http://www.openonload.org/) files.  The two commits address two distinct problems:

1. Permission was already granted in 132fee4 to `container_runtime_t`, but not to `container_t` itself.

1. The implementation of `fs_rw_onload_sockets()` in `selinux-policy` grants permissions only to the `sock_file` class, but `file` and `fifo_file` are also necessary.  There is a PR with a proposed fix at https://github.com/fedora-selinux/selinux-policy/pull/251, but in the meantime, there is a commit in the current PR that overrides `fs_rw_onload_sockets()` with a fixed implementation.  Overriding in this manner is a touch unsavoury, so if it would be preferred, I could rewrite the patch to introduce a new interface rather than overriding the old one.