### PR TITLE
container.fc: label crun

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -16,6 +16,8 @@
 /usr/local/bin/runc		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/sbin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/bin/crun		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/crun			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/container[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/sbin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
set the label for crun to system_u:object_r:container_runtime_exec_t.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>