### PR TITLE
Drop some container interface from selinux-policy

### DIFF
--- a/container.te
+++ b/container.te
@@ -330,6 +330,11 @@ optional_policy(`
 	openvswitch_stream_connect(container_runtime_domain)
 ')
 
+optional_policy(`
+    domain_stub_named_filetrans_domain()
+    container_filetrans_named_content(named_filetrans_domain)
+')
+
 #
 # lxc rules
 #


### PR DESCRIPTION
container_filetrans_named_content macro is called by
named_filetrans_domain attribute to ensure that multiple SELinux domains can create objects on file system with correct SELinux label. This part of policy should be in container-selinux because container types are defined in container-selinux not selinux-policy package.

Relate to: https://github.com/fedora-selinux/selinux-policy/commit/50a6afe26d1b3083c339adc1c5f6193ec0cb71cd