### PR TITLE
Allow container_t to open existing tun/tap

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.144.0)
+policy_module(container, 2.145.0)
 gen_require(`
 	class passwd rootok;
 ')
@@ -725,7 +725,7 @@ allow container_domain self:sem create_sem_perms;
 allow container_domain self:shm create_shm_perms;
 allow container_domain self:socket create_socket_perms;
 allow container_domain self:tcp_socket create_socket_perms;
-allow container_domain self:tun_socket create_socket_perms;
+allow container_domain self:tun_socket { create_socket_perms relabelfrom relabelto };
 allow container_domain self:udp_socket create_socket_perms;
 allow container_domain self:unix_dgram_socket create_socket_perms;
 allow container_domain self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
Fixes #104 - Containers that run processes which open /dev/net/tun and attempt to use an existing named network device in their network namespace (e.g. Qemu) need relabelto/relabelfrom on tun_socket. This is important for use cases where we don't want containers to have NET_ADMIN but still want them to be able to use tap devices that are pre-created for the container.

I'm not sure if this is the ideal fix, but this seems like a good way to get the discussion going if there is a different way. I did check fedora-selinux to see if there were any existing booleans, rules, or interfaces that could be called.

When a userspace process opens /dev/net/tun and attempts to open a tun/tap device by calling ioctl [TUNSETIFF](https://github.com/torvalds/linux/blob/1127b219ce9481c84edad9711626d856127d5e51/drivers/net/tun.c#L2662), one of two things happen:

1) If the named device exists in the network namespace, the kernel [checks](https://github.com/torvalds/linux/blob/34d4ddd359dbcdf6c5fb3f85a179243d7a1cb7f8/security/selinux/hooks.c#L5493) to see if the process has relabelto/relabelfrom, then creates a tun_socket and labels it for the process. Then it attaches the open fd to the socket for the userspace process to use. This does not require NET_ADMIN capabilities, and in fact even if you have NET_ADMIN, the container process will fail on SELinux without this relabelto/relabelfrom capability.

2) If the named device does not exist in the network namespace, the kernel does not call the [function](https://github.com/torvalds/linux/blob/34d4ddd359dbcdf6c5fb3f85a179243d7a1cb7f8/security/selinux/hooks.c#L5493) that checks for these selinux permissions, it simply checks for NET_ADMIN capability and then creates a new network device.