### PR TITLE
container_kvm_t: Allow virtiofsd to write on /tmp

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.145.0)
+policy_module(container, 2.146.0)
 gen_require(`
 	class passwd rootok;
 ')
@@ -1115,6 +1115,8 @@ files_pid_filetrans(container_kvm_t, container_kvm_var_run_t, { dir file lnk_fil
 allow container_kvm_t container_kvm_var_run_t:{file dir} mounton;
 
 allow container_kvm_t container_runtime_t:unix_stream_socket rw_stream_socket_perms;
+
+allow container_kvm_t tmp_t:dir write;
 
 container_stream_connect(container_kvm_t)
 


### PR DESCRIPTION
AVCs:
type=AVC msg=audit(1601481071.991:128): avc:  denied  { write } for  pid=25901 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c534,c983 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481074.628:131): avc:  denied  { write } for  pid=26059 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c238,c525 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481091.365:134): avc:  denied  { write } for  pid=26430 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c679,c727 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481104.890:137): avc:  denied  { write } for  pid=26743 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c471,c990 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481118.496:140): avc:  denied  { write } for  pid=27061 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c323,c818 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481132.776:177): avc:  denied  { write } for  pid=27511 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c86,c882 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481149.601:180): avc:  denied  { write } for  pid=27919 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c511,c934 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481164.283:183): avc:  denied  { write } for  pid=28216 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c525,c803 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481177.469:186): avc:  denied  { write } for  pid=28509 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c340,c372 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0
type=AVC msg=audit(1601481194.026:191): avc:  denied  { write } for  pid=28900 comm="virtiofsd" name="/" dev="tmpfs" ino=14755 scontext=system_u:system_r:container_kvm_t:s0:c416,c453 tcontext=system_u:object_r:tmp_t:s0 tclass=dir permissive=0

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>