### PR TITLE
Allow container to relabel tun/tap device from container_runtime_t

### DIFF
--- a/container.te
+++ b/container.te
@@ -729,6 +729,7 @@ allow container_runtime_domain container_domain:fifo_file rw_fifo_file_perms;
 allow container_domain container_runtime_domain:fifo_file { rw_fifo_file_perms map };
 allow container_domain container_runtime_t:unix_dgram_socket sendto;
 
+allow container_domain container_runtime_domain:tun_socket relabelfrom;
 allow container_domain container_runtime_domain:fd use;
 allow container_runtime_domain container_domain:fd use;
 allow container_domain self:socket_class_set { create_socket_perms map accept };


### PR DESCRIPTION
Fixes cases where the runtime/CNI has created new tap devices as container_runtime_t

```
type=AVC msg=audit(1605647505.495:3870204537): avc:  denied  { relabelfrom } for
pid=3716920 comm="qemu-system-x86" scontext=system_u:system_r:container_t:s0:c484,c585
tcontext=system_u:system_r:container_runtime_t:s0 tclass=tun_socket permissive=0
```

This occurred during a change of our container runtime and CNI, it was found that the tap devices being
created by CNI were inheriting container_runtime_t. These are for the private kernel sockets that represent
the actual tap devices, not the /dev/net/tun interface.

I tried playing with type transitions to see if we could get the private kernel sockets to transition to container_t,
but I couldn't quite work out what the target type was for these private sockets, or couldn't find something that
worked.

It may also be possible to relabel all of the cni binaries, or create some other form of type transition so the CNI
process runs as container_t, but that is likely fraught with other issues.


