### PR TITLE
adjust container_filetrans_named_content gen_require

### DIFF
--- a/container.if
+++ b/container.if
@@ -493,6 +493,7 @@ interface(`container_filetrans_named_content',`
 	type container_home_t;
 	type kubernetes_file_t;
 	type container_runtime_tmpfs_t;
+	type container_kvm_var_run_t;
     ')
 
     files_pid_filetrans($1, container_var_run_t, file, "container.pid")


### PR DESCRIPTION
The container_filetrans_named_content macro calls out to the
files_pid_filetrans macro for the "kata-containers" dir passing a type
missing from the gen_require stanza. This is causing my downstream
builds of rke2-selinux to fail (current work-around is to require
container_kvm_var_run_t in our rke2_filetrans_named_content macro).

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
