### PR TITLE
Allow spc_t to use BPF-related system calls

### DIFF
--- a/container.te
+++ b/container.te
@@ -644,6 +644,7 @@ admin_pattern(spc_t, kubernetes_file_t)
 
 allow spc_t container_runtime_domain:fifo_file manage_fifo_file_perms;
 allow spc_t { container_ro_file_t container_file_t }:system module_load;
+allow spc_t container_runtime_domain:bpf { map_create map_read map_write prog_load prog_run };
 
 allow container_runtime_domain spc_t:process { setsched signal_perms };
 ps_process_pattern(container_runtime_domain, spc_t)


### PR DESCRIPTION
The SELinux context spc_t is a Super Privileged Container type. Therefore, it should be allowed to use BPF-related system calls.

This is especially important to support cgroups v2. In v2, as opposed to v1, the devices subsystem is implemented by using eBPF programs (instead of v1's file-system interface).

Therefore, libcontainer[1] cannot perform its task of modifying cgroups device permissions in v2.

[1] https://github.com/opencontainers/runc/blob/v1.0.0/libcontainer/cgroups/fs2/devices.go#L57

P.S. this is also probably related to [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1980405).