### PR TITLE
Replace "//" with "#"

### DIFF
--- a/container.te
+++ b/container.te
@@ -667,8 +667,8 @@ optional_policy(`
 optional_policy(`
 	unconfined_domain_noaudit(spc_t)
 	domain_ptrace_all_domains(spc_t)
-	// This should eventually be in upstream policy.
-	// https://github.com/fedora-selinux/selinux-policy/pull/806
+	# This should eventually be in upstream policy.
+	# https://github.com/fedora-selinux/selinux-policy/pull/806
 	allow spc_t domain:bpf { map_create map_read map_write prog_load prog_run };
 ')
 


### PR DESCRIPTION
In commit 4c51e97504d ("Allow spc_t domains to set bpf rules on any domain"),
a comment is introduced with double-slash symbol which is not
considered valid in policy sources.

Addresses the following problem:
/usr/bin/checkmodule -m tmp/container.tmp -o tmp/container.mod
policy/modules/contrib/container.te:667:ERROR 'syntax error' at token '//' on line 25264:
	// This should eventually be in upstream policy.
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [Rules.modular:77: tmp/container.mod] Error 1
rm tmp/container.mod.fc
Error: Process completed with exit code 2.