### PR TITLE
Add support for k3s

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -35,10 +35,13 @@
 /usr/lib/docker/docker-novolume-plugin	--	gen_context(system_u:object_r:container_auth_exec_t,s0)
 /usr/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/k3s		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/bin/k3s		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 
 /usr/lib/systemd/system/docker.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/lib/systemd/system/lxd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/lib/systemd/system/containerd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
+/usr/lib/systemd/system/k3s.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 
 /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/docker-latest(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
@@ -104,6 +107,21 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/lib/docker-latest/init(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker-latest/overlay(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker-latest/overlay2(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+
+/var/lib/cni(/.*)?								gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/rancher/k3s(/.*)?							gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/rancher/k3s/data(/.*)?							gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/var/lib/rancher/k3s/storage(/.*)?						gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots			-d	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*		-d	gen_context(system_u:object_r:container_share_t,s0)
+/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*			<<none>>
+/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?			gen_context(system_u:object_r:container_share_t,s0)
+/var/run/flannel(/.*)?								gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/k3s(/.*)?								gen_context(system_u:object_r:container_var_run_t,s0)
+/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?				gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
+/var/lib/kubelet/pods(/.*)?							gen_context(system_u:object_r:container_file_t,s0)
+/var/log/containers(/.*)?							gen_context(system_u:object_r:container_log_t,s0)
+/var/log/pods(/.*)?								gen_context(system_u:object_r:container_log_t,s0)
 
 /var/run/containers(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)
 /var/run/crio(/.*)?		gen_context(system_u:object_r:container_var_run_t,s0)


### PR DESCRIPTION
This integrates SELinux policy rules from the [k3s-selinux package](https://github.com/k3s-io/k3s-selinux)
so that k3s works on SELinux out of the box.