### PR TITLE
remove k3s fcontexts

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -35,13 +35,10 @@
 /usr/lib/docker/docker-novolume-plugin	--	gen_context(system_u:object_r:container_auth_exec_t,s0)
 /usr/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/lib/docker/[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
-/usr/bin/k3s		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
-/usr/local/bin/k3s		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 
 /usr/lib/systemd/system/docker.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/lib/systemd/system/lxd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 /usr/lib/systemd/system/containerd.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
-/usr/lib/systemd/system/k3s.*		--	gen_context(system_u:object_r:container_unit_file_t,s0)
 
 /etc/docker(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /etc/docker-latest(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
@@ -109,18 +106,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/lib/docker-latest/overlay2(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 
 /var/lib/cni(/.*)?								gen_context(system_u:object_r:container_var_lib_t,s0)
-/var/lib/rancher/k3s(/.*)?							gen_context(system_u:object_r:container_var_lib_t,s0)
-/var/lib/rancher/k3s/data(/.*)?							gen_context(system_u:object_r:container_runtime_exec_t,s0)
-/var/lib/rancher/k3s/storage(/.*)?						gen_context(system_u:object_r:container_file_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots			-d	gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*		-d	gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/rancher/k3s/agent/containerd/[^/]*/snapshots/[^/]*/.*			<<none>>
-/var/lib/rancher/k3s/agent/containerd/[^/]*/sandboxes(/.*)?			gen_context(system_u:object_r:container_share_t,s0)
-/var/lib/rancher/k3s/data/.lock                                     gen_context(system_u:object_r:container_lock_t,s0)
-/var/lib/rancher/k3s/data/[^/]*/etc(/.*)?                           gen_context(system_u:object_r:container_config_t,s0)
 /var/run/flannel(/.*)?								gen_context(system_u:object_r:container_var_run_t,s0)
-/var/run/k3s(/.*)?								gen_context(system_u:object_r:container_var_run_t,s0)
-/var/run/k3s/containerd/[^/]*/sandboxes/[^/]*/shm(/.*)?				gen_context(system_u:object_r:container_runtime_tmpfs_t,s0)
 /var/lib/kubelet/pods(/.*)?							gen_context(system_u:object_r:container_file_t,s0)
 /var/log/containers(/.*)?							gen_context(system_u:object_r:container_log_t,s0)
 /var/log/pods(/.*)?								gen_context(system_u:object_r:container_log_t,s0)


### PR DESCRIPTION
K3s brings its own embedded userland runtime and dumps it on disk under
/var/lib/rancher/k3s/data/${content_id=-"current"}/ which includes runc,
containerd, and the containerd shims. The initial k3s policy implementation
re-used existing policy types from container-selinux and marked all of
the disgorged userland (binaries and config, alike) as
container_runtime_exec_t which is what runc and the containerd bits
require. Because we ship busybox in this userland, with the shell
applet, this can lead to elevated privileges for any unconfined seuser
(the default for unmodified installations).

To address this problem we have re-written the k3s-selinux policy to
declare and leverage a couple of custom types for the various bits of
"content" that k3s brings. As such, the k3s-specific file-contexts that
were pushed upstream to here with containers/container-selinux#140 and
recently modified with containers/container-selinux#156 are no longer
appropriate to be maintained here. This PR removes the k3s-specific
file-context entries for:
- systemd units
- k3s binaries under /usr and /usr/local
- everything under /var/lib/rancher/k3s and /var/run/k3s

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>
