### PR TITLE
Add missing dbus class declaration into container_runtime_run()

### DIFF
--- a/container.if
+++ b/container.if
@@ -40,6 +40,7 @@ interface(`container_runtime_domtrans',`
 interface(`container_runtime_run',`
 	gen_require(`
 		type container_runtime_t;
+		class dbus send_msg;
 	')
 
 	container_runtime_domtrans($1)


### PR DESCRIPTION
The container_runtime_run() interface does not contain the dbus class
declaration which under some conditions makes the interface not compile:

  $ sepolicy interface -c -i container_runtime_run
Compiling container_runtime_run interface
Compiling targeted compiletest module
compiletest.te:43:ERROR 'unknown class dbus' at token ';' on line 4492:
	allow sepolicy_domain_t container_runtime_t:dbus send_msg;
  #line 43
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
make: *** [/usr/share/selinux/devel/include/Makefile:157: tmp/compiletest.mod] Error 1
Compile test for container_runtime_run failed.

Resolves: rhbz#1967642