### PR TITLE
Update file labeling type for /var/lib/kubelet

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -95,7 +95,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/lib/origin(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 
-/var/lib/kublet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker-latest(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)


### PR DESCRIPTION
Kubelet is misspelled, so /var/lib/kubelet is not properly labeled by this policy. 