### PR TITLE
Add explicit range transition for conmon

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -19,6 +19,8 @@
 /usr/libexec/lxd/.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/podman		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/bin/podman		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/bin/conmon		--	gen_context(system_u:object_r:conmon_exec_t,s0)
+/usr/local/bin/conmon		--	gen_context(system_u:object_r:conmon_exec_t,s0)
 /usr/local/s?bin/runc		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/s?bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/s?bin/crun		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)

--- a/container.te
+++ b/container.te
@@ -45,6 +45,16 @@ allow container_domain container_runtime_domain:process sigchld;
 allow container_runtime_domain container_domain:process2 { nnp_transition nosuid_transition };
 dontaudit container_runtime_domain container_domain:process { noatsecure rlimitinh siginh };
 
+type conmon_exec_t;
+application_executable_file(conmon_exec_t)
+can_exec(container_runtime_t, conmon_exec_t)
+ifdef(`enable_mcs',`
+	range_transition container_runtime_t conmon_exec_t:process s0;
+')
+ifdef(`enable_mls',`
+	range_transition container_runtime_t conmon_exec_t:process s0;
+')
+
 type spc_t, container_domain;
 domain_type(spc_t)
 role system_r types spc_t;


### PR DESCRIPTION
Assign the conmon executable a private type and explicitly add a ranged
transition such that podman runs conmon in s0.

This is a companion PR to https://github.com/containers/podman/pull/13093

Fixes: #152 