### PR TITLE
Add a domain for intelplugins and give them required access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS?=container
+TARGETS?=container intelplugins
 MODULES?=${TARGETS:=.pp.bz2}
 SHAREDIR?=/usr/share
 

--- a/intelplugins.te
+++ b/intelplugins.te
@@ -1,0 +1,13 @@
+policy_module(intelplugins, 1.0)
+
+gen_require(`
+        type container_file_t;
+        type device_t;
+')
+
+container_domain_template(intelplugins)
+
+#============= intelplugins_t ==============
+allow intelplugins_t container_runtime_t:unix_stream_socket connectto;
+allow intelplugins_t device_t:chr_file getattr;
+


### PR DESCRIPTION
This pach creates a domain to use by intel plugins and gives it access
to things like device_t and socket connection.

Signed-off-by: Manish Regmi <manish.regmi@intel.com>