### PR TITLE
Support BuildKit (cont.)

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -28,6 +28,8 @@
 /usr/local/bin/conmon		--	gen_context(system_u:object_r:conmon_exec_t,s0)
 /usr/local/s?bin/runc		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/s?bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/buildkit-runc	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/buildkit-runc	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/s?bin/crun		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/s?bin/crun			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/container[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
@@ -68,11 +70,17 @@
 /var/lib/docker/overlay2(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 
 /var/lib/containerd(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
-/var/lib/containerd/[^/]*/snapshots(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+# The "snapshots" directory of containerd and BuildKit must be writable, as it is used as an upperdir as well as a lowerdir.
+/var/lib/containerd/[^/]*/snapshots(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/containerd/[^/]*/sandboxes(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 
 /var/lib/buildkit(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
-/var/lib/buildkit/[^/]*/snapshots(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+/var/lib/buildkit/[^/]*/snapshots(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
+# "/var/lib/buildkit/runc-<SNAPSHOTTER>/executor" contains "resolv.conf" and "hosts.<RANDOM>", for OCI (runc) worker mode.
+/var/lib/buildkit/runc-.*/executor(/.*?)	gen_context(system_u:object_r:container_ro_file_t,s0)
+# "/var/lib/buildkit/containerd-<SNAPSHOTTER>" contains resolv.conf and hosts.<RANDOM>, for containerd worker mode.
+# Unlike the runc-<SNAPSHOTTER> directory, this directory does not contain the "executor" directory inside it.
+/var/lib/buildkit/containerd-.*(/.*?)	gen_context(system_u:object_r:container_ro_file_t,s0)
 
 HOME_DIR/\.local/share/containers/storage/overlay(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
 HOME_DIR/\.local/share/containers/storage/overlay2(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)

--- a/container.if
+++ b/container.if
@@ -520,6 +520,7 @@ interface(`container_filetrans_named_content',`
     files_var_lib_filetrans($1, container_var_lib_t, dir, "docker-latest")
     files_var_filetrans($1, container_ro_file_t, dir, "kata-containers")
     files_var_lib_filetrans($1, container_ro_file_t, dir, "kata-containers")
+    files_var_lib_filetrans($1, container_var_lib_t, dir, "containerd")
     files_var_lib_filetrans($1, container_var_lib_t, dir, "buildkit")
 
     filetrans_pattern($1, container_var_lib_t, container_file_t, dir, "_data")
@@ -528,7 +529,11 @@ interface(`container_filetrans_named_content',`
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, file, "hostname")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, file, "resolv.conf")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "sandboxes")
-    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "snapshots")
+    # The "snapshots" directory of containerd and BuildKit must be writable, as it is used as an upperdir as well as a lowerdir.
+    # (lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs,
+    #  upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/fs,
+    #  workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/work)
+    filetrans_pattern($1, container_var_lib_t, container_file_t, dir, "snapshots")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "init")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "overlay")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "overlay-images")
@@ -536,6 +541,24 @@ interface(`container_filetrans_named_content',`
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "overlay2")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "overlay2-images")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "overlay2-layers")
+
+    # "/var/lib/buildkit/runc-<SNAPSHOTTER>/executor" contains "resolv.conf" and "hosts.<RANDOM>", for OCI (runc) worker mode.
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "executor")
+
+    # "/var/lib/buildkit/containerd-<SNAPSHOTTER>" contains resolv.conf and hosts.<RANDOM>, for containerd worker mode.
+    # Unlike the runc-<SNAPSHOTTER> directory, this directory does not contain the "executor" directory inside it.
+    # Core snapshotters
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-overlayfs")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-native")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-btrfs")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-zfs")
+    # Non-core snapshotters
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-fuse-overlayfs")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-nydus")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-overlaybd")
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-stargz")
+    # Third-party snapshotters
+    filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-soci")
 
     filetrans_pattern($1, data_home_t, container_ro_file_t, dir, "overlay")
     filetrans_pattern($1, data_home_t, container_ro_file_t, dir, "overlay-images")

--- a/container_selinux.8
+++ b/container_selinux.8
@@ -1,4 +1,4 @@
-.TH  "container_selinux"  "8"  "22-10-19" "container" "SELinux Policy container"
+.TH  "container_selinux"  "8"  "22-10-20" "container" "SELinux Policy container"
 .SH "NAME"
 container_selinux \- Security Enhanced Linux Policy for the container processes
 .SH "DESCRIPTION"
@@ -115,7 +115,11 @@ The SELinux process type container_t can manage files labeled with the following
 .br
 	/var/lib/rkt/cas(/.*)?
 .br
+	/var/lib/buildkit/[^/]*/snapshots(/.*)?
+.br
 	/var/srv/containers(/.*)?
+.br
+	/var/lib/containerd/[^/]*/snapshots(/.*)?
 .br
 	/var/lib/kubelet/pods(/.*)?
 .br
@@ -293,7 +297,7 @@ Paths:
 .br
 .TP 5
 Paths:
-/srv/containers(/.*)?, /var/lib/origin(/.*)?, /var/lib/rkt/cas(/.*)?, /var/srv/containers(/.*)?, /var/lib/kubelet/pods(/.*)?, /var/lib/kubernetes/pods(/.*)?, /var/lib/containers/storage/volumes/[^/]*/.*, /home/[^/]+/\.local/share/containers/storage/volumes/[^/]*/.*
+/srv/containers(/.*)?, /var/lib/origin(/.*)?, /var/lib/rkt/cas(/.*)?, /var/lib/buildkit/[^/]*/snapshots(/.*)?, /var/srv/containers(/.*)?, /var/lib/containerd/[^/]*/snapshots(/.*)?, /var/lib/kubelet/pods(/.*)?, /var/lib/kubernetes/pods(/.*)?, /var/lib/containers/storage/volumes/[^/]*/.*, /home/[^/]+/\.local/share/containers/storage/volumes/[^/]*/.*
 
 .EX
 .PP
@@ -349,7 +353,7 @@ Paths:
 .br
 .TP 5
 Paths:
-/var/lib/docker/.*/config\.env, /var/lib/buildkit/[^/]*/snapshots(/.*)?, /var/lib/docker/init(/.*)?, /var/lib/containerd/[^/]*/sandboxes(/.*)?, /var/lib/containerd/[^/]*/snapshots(/.*)?, /var/lib/docker/overlay(/.*)?, /var/lib/ocid/sandboxes(/.*)?, /var/lib/docker-latest/.*/config\.env, /var/lib/docker/overlay2(/.*)?, /var/lib/kata-containers(/.*)?, /var/cache/kata-containers(/.*)?, /var/lib/containers/overlay(/.*)?, /var/lib/docker-latest/init(/.*)?, /var/lib/docker/containers/.*/hosts, /var/lib/docker/containers/.*/hostname, /var/lib/containers/overlay2(/.*)?, /var/lib/docker-latest/overlay(/.*)?, /var/lib/docker-latest/overlay2(/.*)?, /var/lib/containers/overlay-images(/.*)?, /var/lib/containers/overlay-layers(/.*)?, /var/lib/docker-latest/containers/.*/hosts, /var/lib/docker-latest/containers/.*/hostname, /var/lib/containers/overlay2-images(/.*)?, /var/lib/containers/overlay2-layers(/.*)?, /var/lib/containers/storage/overlay(/.*)?, /var/lib/containers/storage/overlay2(/.*)?, /var/lib/containers/storage/overlay-images(/.*)?, /var/lib/containers/storage/overlay-layers(/.*)?, /var/lib/containers/storage/overlay2-images(/.*)?, /var/lib/containers/storage/overlay2-layers(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay-images(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay-layers(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2-images(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2-layers(/.*)?
+/var/lib/docker/.*/config\.env, /var/lib/docker/init(/.*)?, /var/lib/containerd/[^/]*/sandboxes(/.*)?, /var/lib/docker/overlay(/.*)?, /var/lib/ocid/sandboxes(/.*)?, /var/lib/docker-latest/.*/config\.env, /var/lib/buildkit/runc-.*/executor(/.*?), /var/lib/docker/overlay2(/.*)?, /var/lib/kata-containers(/.*)?, /var/cache/kata-containers(/.*)?, /var/lib/containers/overlay(/.*)?, /var/lib/docker-latest/init(/.*)?, /var/lib/docker/containers/.*/hosts, /var/lib/docker/containers/.*/hostname, /var/lib/containers/overlay2(/.*)?, /var/lib/buildkit/containerd-.*(/.*?), /var/lib/docker-latest/overlay(/.*)?, /var/lib/docker-latest/overlay2(/.*)?, /var/lib/containers/overlay-images(/.*)?, /var/lib/containers/overlay-layers(/.*)?, /var/lib/docker-latest/containers/.*/hosts, /var/lib/docker-latest/containers/.*/hostname, /var/lib/containers/overlay2-images(/.*)?, /var/lib/containers/overlay2-layers(/.*)?, /var/lib/containers/storage/overlay(/.*)?, /var/lib/containers/storage/overlay2(/.*)?, /var/lib/containers/storage/overlay-images(/.*)?, /var/lib/containers/storage/overlay-layers(/.*)?, /var/lib/containers/storage/overlay2-images(/.*)?, /var/lib/containers/storage/overlay2-layers(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay-images(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay-layers(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2-images(/.*)?, /home/[^/]+/\.local/share/containers/storage/overlay2-layers(/.*)?
 
 .EX
 .PP
@@ -361,7 +365,7 @@ Paths:
 .br
 .TP 5
 Paths:
-/usr/s?bin/lxc, /usr/s?bin/lxd, /usr/s?bin/crun, /usr/s?bin/runc, /usr/s?bin/crio.*, /usr/s?bin/lxc-.*, /usr/s?bin/lxd-.*, /usr/s?bin/ocid.*, /usr/s?bin/docker.*, /usr/s?bin/fuidshift, /usr/s?bin/buildkitd.*, /usr/s?bin/containerd.*, /usr/s?bin/docker-latest, /usr/s?bin/docker-current, /usr/local/s?bin/crun, /usr/local/s?bin/runc, /usr/local/s?bin/crio.*, /usr/local/s?bin/docker.*, /usr/local/s?bin/buildkitd.*, /usr/local/s?bin/containerd.*, /usr/lib/docker/[^/]*plugin, /usr/libexec/lxc/.*, /usr/libexec/lxd/.*, /usr/bin/container[^/]*plugin, /usr/libexec/docker/.*, /usr/local/lib/docker/[^/]*plugin, /usr/libexec/docker/docker.*, /usr/local/libexec/docker/.*, /usr/local/libexec/docker/docker.*, /usr/bin/podman, /usr/local/bin/podman, /usr/bin/rhel-push-plugin, /usr/sbin/rhel-push-plugin
+/usr/s?bin/lxc, /usr/s?bin/lxd, /usr/s?bin/crun, /usr/s?bin/runc, /usr/s?bin/crio.*, /usr/s?bin/lxc-.*, /usr/s?bin/lxd-.*, /usr/s?bin/ocid.*, /usr/s?bin/docker.*, /usr/s?bin/fuidshift, /usr/s?bin/buildkitd.*, /usr/s?bin/containerd.*, /usr/s?bin/buildkit-runc, /usr/s?bin/docker-latest, /usr/s?bin/docker-current, /usr/local/s?bin/crun, /usr/local/s?bin/runc, /usr/local/s?bin/crio.*, /usr/local/s?bin/docker.*, /usr/local/s?bin/buildkitd.*, /usr/local/s?bin/containerd.*, /usr/local/s?bin/buildkit-runc, /usr/lib/docker/[^/]*plugin, /usr/libexec/lxc/.*, /usr/libexec/lxd/.*, /usr/bin/container[^/]*plugin, /usr/libexec/docker/.*, /usr/local/lib/docker/[^/]*plugin, /usr/libexec/docker/docker.*, /usr/local/libexec/docker/.*, /usr/local/libexec/docker/docker.*, /usr/bin/podman, /usr/local/bin/podman, /usr/bin/rhel-push-plugin, /usr/sbin/rhel-push-plugin
 
 .EX
 .PP


### PR DESCRIPTION
PR #189 (6e07a445ca54fe0d973b08d4f62ebb7ae8765eef) was immaturely merged and never worked with file write operations and DNS operations.

This commit includes the following fixes:

- Change the type of the `snapshots` directory from `container_ro_file_t` to `container_file_t`, as it is used as an upperdir as well as a lowerdir.

  OCI (runc) worker mode:
  lowerdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/3/fs
  upperdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/4/fs
  workdir=/var/lib/buildkit/runc-overlayfs/snapshots/snapshots/4/work

  containerd worker mode:
  lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs 
  upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/fs
  workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/4/work

- Add `files_var_lib_filetrans($1, container_var_lib_t, dir, "containerd")` to initialize `/var/lib/containerd` for containerd mode.

- Add `filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "executor")` for `/var/lib/buildkit/runc-<SNAPSHOTTER>/executor`. 
  This directory contains `resolv.conf` and `hosts.<RANDOM>` for OCI (runc) worker mode.

- Add `filetrans_pattern($1, container_var_lib_t, container_ro_file_t, dir, "containerd-overlayfs")` for `/var/lib/buildkit/containerd-<SNAPSHOTTER>`. 
  This directory contains `resolv.conf` and `hosts.<RANDOM>` for containerd worker mode. 
  Unlike the `runc-<SNAPSHOTTER>` directory, this directory does not contain the `executor` directory inside it.

This commit is tested with both OCI (runc) worker mode and containerd worker mode, using a simple Dockerfile like `RUN apk add neofetch` on Fedora 36, BuildKit v0.10.5, runc v1.1.4, and containerd v1.6.8.

Fix #190

Note that this still does not work with `RUN --mount=type=secret`, as the container processes with the `container_t` type can't access the tmpfs mounts with the `container_runtime_tmpfs_t` on `/tmp/buildkit-secrets<RANDOM>`.

