### PR TITLE
container.fc: Set label for kata-agent

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -30,6 +30,8 @@
 /usr/s?bin/runc			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/s?bin/crun		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/s?bin/crun			--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/local/s?bin/kata-agent	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/usr/s?bin/kata-agent		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/container[^/]*plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/bin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/sbin/rhel-push-plugin	--	gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
Set the label for `kata-agent` to `system_u:object_r:container_runtime_exec_t` because Kata Containers will start supporting for SELinux on the guest side.

`kata-agent` spawns and runs containers inside Kata VM, so it behaves like a general container runtime. To enable SELinux on the Kata VM, `kata-agent` should be labeled as `container_runtime_exec_t`.

Ref. https://github.com/kata-containers/kata-containers/pull/4813

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>