### PR TITLE
Allow containers to mount tmpfs_t file systems

### DIFF
--- a/container.te
+++ b/container.te
@@ -836,6 +836,7 @@ container_spc_stream_connect(container_domain)
 fs_dontaudit_remount_tmpfs(container_domain)
 dev_dontaudit_mounton_sysfs(container_domain)
 dev_dontaudit_mounton_sysfs(container_domain)
+fs_mount_tmpfs(container_domain)
 
 dontaudit container_domain container_runtime_tmpfs_t:dir read;
 allow container_domain container_runtime_tmpfs_t:dir mounton;


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

The policy is needed for Passt, see [passt.te](https://passt.top/passt/tree/contrib/selinux/passt.te#n82)
 for reference.

