### PR TITLE
Allow spc_t to use timedatectl

### DIFF
--- a/container.te
+++ b/container.te
@@ -705,6 +705,7 @@ init_dbus_chat(spc_t)
 optional_policy(`
 	systemd_dbus_chat_machined(spc_t)
 	systemd_dbus_chat_logind(spc_t)
+	systemd_dbus_chat_timedated(spc_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
Allow spc_t to use timedatectl

Signed-off-by: Johannes Segitz <jsegitz@suse.de>