### PR TITLE
Add system_r role to rpm_transition_script(spc_t)

### DIFF
--- a/container.te
+++ b/container.te
@@ -1013,7 +1013,7 @@ optional_policy(`
 optional_policy(`
 	rpm_read_cache(container_domain)
 	rpm_read_db(container_domain)
-	rpm_transition_script(spc_t)
+	rpm_transition_script(spc_t, system_r)
 ')
 
 optional_policy(`


### PR DESCRIPTION
With the 018cb36d55 ("Allow spc_t to transption to rpm_script_t") commit, spc_t was allowed to transition to the rpm_script_t domain. The interface, however, requires 2 arguments, the second one being role allowed access.