### PR TITLE
Allow containers to watch sysfs_t directories

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.203.0)
+policy_module(container, 2.204.0)
 
 gen_require(`
 	class passwd rootok;
@@ -865,6 +865,8 @@ allow container_domain container_runtime_tmpfs_t:dir mounton;
 
 dev_getattr_mtrr_dev(container_domain)
 dev_list_sysfs(container_domain)
+allow container_domain sysfs_t:dir watch;
+
 dev_rw_kvm(container_domain)
 dev_rwx_zero(container_domain)
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2177273