### PR TITLE
set default context for local-path-provisioner

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -116,6 +116,8 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 
 /var/run/kata-containers(/.*)?	gen_context(system_u:object_r:container_kvm_var_run_t,s0)
 
+/(var|opt)/local-path-provisioner(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
+
 /var/lib/origin(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 


### PR DESCRIPTION
The kubernetes local-path-provisioner uses either
/opt/local-path-provisioner or
/var/local-path-provisioner for its physical volumes