### PR TITLE
Allow daemon to send dbus messages to spc_t

### DIFF
--- a/container.if
+++ b/container.if
@@ -997,7 +997,6 @@ interface(`container_kubelet_domtrans',`
 interface(`container_kubelet_run',`
 	gen_require(`
 		type kubelet_t;
-		class dbus send_msg;
 	')
 
 	container_kubelet_domtrans($1)

--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.210.0)
+policy_module(container, 2.211.0)
 
 gen_require(`
 	class passwd rootok;
@@ -731,6 +731,7 @@ optional_policy(`
 	# This should eventually be in upstream policy.
 	# https://github.com/fedora-selinux/selinux-policy/pull/806
 	allow spc_t domain:bpf { map_create map_read map_write prog_load prog_run };
+	allow daemon spc_t:dbus send_msg;
 ')
 
 optional_policy(`
@@ -998,7 +999,6 @@ allow container_net_domain self:socket create_socket_perms;
 allow container_net_domain self:rawip_socket create_stream_socket_perms;
 allow container_net_domain self:netlink_kobject_uevent_socket create_socket_perms;
 allow container_net_domain self:netlink_xfrm_socket create_netlink_socket_perms;
-
 
 kernel_unlabeled_domtrans(container_runtime_domain, spc_t)
 kernel_unlabeled_entry_type(spc_t)


### PR DESCRIPTION
When users run dbus based applications as containers, they expect other processes to dbus chat with them.  I don't want to allow all domains to dbus chat since this would include container_t. Allowing daemon, will allow the bulk of confined domains to interact with spc_t.