### PR TITLE
Add labels for /var/lib/shared

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -59,6 +59,7 @@
 /etc/crio(/.*)?		gen_context(system_u:object_r:container_config_t,s0)
 /exports(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 
+/var/lib/shared(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/registry(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/lxc(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/lxd(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)

--- a/container.if
+++ b/container.if
@@ -522,6 +522,7 @@ interface(`container_filetrans_named_content',`
     files_var_lib_filetrans($1, container_ro_file_t, dir, "kata-containers")
     files_var_lib_filetrans($1, container_var_lib_t, dir, "containerd")
     files_var_lib_filetrans($1, container_var_lib_t, dir, "buildkit")
+    files_var_lib_filetrans($1, container_ro_file_t, dir, "shared")
 
     filetrans_pattern($1, container_var_lib_t, container_file_t, dir, "_data")
     filetrans_pattern($1, container_var_lib_t, container_ro_file_t, file, "config.env")


### PR DESCRIPTION
We have been talking about this directory for years for shared storage of container images, so setting the SELinux labels for it.