### PR TITLE
allow container_device_plugin_t access to debugfs

### DIFF
--- a/container.te
+++ b/container.te
@@ -1413,6 +1413,7 @@ allow container_device_t device_node:chr_file rw_chr_file_perms;
 container_domain_template(container_device_plugin, container)
 allow container_device_plugin_t device_node:chr_file rw_chr_file_perms;
 dev_rw_sysfs(container_device_plugin_t)
+kernel_read_debugfs(container_device_plugin_t)
 container_kubelet_stream_connect(container_device_plugin_t)
 
 # Standard container which needs to be allowed to use any device and


### PR DESCRIPTION
One of a new device plugin for openshift we are working on (QAT), requires access to debugfs. So allow container_device_plugin_t access to debugfs.