### PR TITLE
Allow container runtime to dyntransition to spc_t

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.214.0)
+policy_module(container, 2.215.0)
 
 gen_require(`
 	class passwd rootok;
@@ -728,7 +728,7 @@ admin_pattern(spc_t, kubernetes_file_t)
 allow spc_t container_runtime_domain:fifo_file manage_fifo_file_perms;
 allow spc_t { container_ro_file_t container_file_t }:system module_load;
 
-allow container_runtime_domain spc_t:process { setsched signal_perms };
+allow container_runtime_domain spc_t:process { dyntransition setsched signal_perms };
 ps_process_pattern(container_runtime_domain, spc_t)
 allow container_runtime_domain spc_t:socket_class_set { relabelto relabelfrom };
 allow spc_t unlabeled_t:key manage_key_perms;


### PR DESCRIPTION
Podman container checkpoint/restore needs to be able to dyntrans from container_runtime_t to spc_t.