### PR TITLE
Packit/TMT: enable CentOS Stream, RHEL [8,9] tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,6 +23,7 @@ jobs:
       - epel-8
 
   # Run on commit to main branch
+  # Build targets managed in copr settings
   - job: copr_build
     trigger: commit
     notifications:
@@ -34,6 +35,7 @@ jobs:
     enable_net: true
 
   # All tests specified in the `/plans/` subdir
+  # Podman e2e tests for Fedora and CentOS Stream
   - job: tests
     trigger: pull_request
     notifications:
@@ -41,12 +43,12 @@ jobs:
         message: "podman e2e tests failed. @containers/packit-build please check."
     targets: &pr_test_targets
       - fedora-all
-        # TODO: re-enable these once https://github.com/containers/podman/pull/20262 is merged.
-        #- epel-9
-        #- epel-8
+      - epel-9
+      - epel-8
     identifier: podman_e2e_test
     tmt_plan: "/plans/podman_e2e_test"
 
+  # Podman system tests for Fedora and CentOS Stream
   - job: tests
     trigger: pull_request
     notifications:
@@ -54,6 +56,32 @@ jobs:
         message: "podman system tests failed. @containers/packit-build please check."
     targets: *pr_test_targets
     identifier: podman_system_test
+    tmt_plan: "/plans/podman_system_test"
+
+  # Podman e2e tests for RHEL
+  - job: tests
+    trigger: pull_request
+    use_internal_tf: true
+    notifications:
+      failure_comment:
+        message: "podman e2e tests failed on RHEL. @containers/packit-build please check."
+    targets: &pr_test_targets_rhel
+      epel-9-x86_64:
+        distros: [RHEL-9.2.0-Nightly]
+      epel-8-x86_64:
+        distros: [RHEL-8.10.0-Nightly]
+    identifier: podman_e2e_test_internal
+    tmt_plan: "/plans/podman_e2e_test"
+
+  # Podman system tests for RHEL
+  - job: tests
+    trigger: pull_request
+    use_internal_tf: true
+    notifications:
+      failure_comment:
+        message: "podman system tests failed on RHEL. @containers/packit-build please check."
+    targets: *pr_test_targets_rhel
+    identifier: podman_system_test_internal
     tmt_plan: "/plans/podman_system_test"
 
   - job: propose_downstream

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,18 +1,28 @@
+# tmt does provide the `adjust` attribute to manage distro conditionals, but
+# the bash way has been rather convenient to read, manage and copy-paste
+# Ref: https://tmt.readthedocs.io/en/stable/spec/core.html#adjust
 prepare:
-    - name: Disable testing-farm dnf repos
-      how: shell
+    - how: shell
       script: |
-        if [ $(rpm --eval %{rhel}) <= 8 ]; then
+        RHEL_RELEASE=$(rpm --eval %{?rhel})
+        ARCH=$(uname -m)
+        if [ $RHEL_RELEASE -eq 8 ]; then
             echo "Disabling container-tools module..."
             dnf -y module disable container-tools
         fi
-        if [[ ! -f /etc/redhat-release || $(rpm --eval %{?fedora}) > 37 ]]; then
-            echo "Disabling testing-farm-tag-repository dnf repo for F38+..."
-            dnf config-manager --disable testing-farm-tag-repository
+        if [ -f /etc/centos-release ]; then
+            echo "Installing epel-release..."
+            dnf -y install epel-release
+        elif [ $RHEL_RELEASE -ge 8 ]; then
+            echo "Installing epel-release..."
+            dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$RHEL_RELEASE.noarch.rpm
+            echo "Enabling epel repo..."
+            dnf config-manager --set-enabled epel
+            cat /etc/yum.repos.d/epel.repo
         fi
-    - name: Install packages
-      how: install
-      copr: rhcontainerbot/podman-next
+        dnf -y copr enable rhcontainerbot/podman-next
+        dnf config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"
+    - how: install
       package:
         - bats
         - golang
@@ -24,8 +34,10 @@ prepare:
     execute:
         how: tmt
         script: |
-            echo "Checking installed versions of golang, podman and podman-tests..."
-            rpm -q container-selinux golang podman podman-tests
+            echo "Checking /etc/redhat-release..."
+            cat /etc/redhat-release
+            echo "Checking installed versions of required packages..."
+            rpm -q container-selinux golang podman
             if [ -f /etc/fedora-release ]; then
                 echo "Resizing tmpfs..."
                 mount -o remount,size=10G /tmp
@@ -44,7 +56,9 @@ prepare:
     execute:
         how: tmt
         script: |
-            echo "Checking versions of podman and podman-tests..."
+            echo "Checking /etc/redhat-release..."
+            cat /etc/redhat-release
+            echo "Checking installed versions of required packages..."
             rpm -q container-selinux podman podman-tests
             echo "Running podman system tests..."
             bats /usr/bin/podman /usr/share/podman/test/system/410-selinux.bats


### PR DESCRIPTION
This commit enables podman system and e2e tests for CentOS Stream and
RHEL, both 8 and 9.
    
The rhel tests run on the internal testing farm and have an `internal`
suffix appended for clarity. Only people with
access to the internal redhat network can access the logs.
