### PR TITLE
packit: Build PRs into default packit COPRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,43 +2,29 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-# Build targets can be found at:
-# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
-
 specfile_path: rpm/container-selinux.spec
 upstream_tag_template: v{version}
 
+srpm_build_deps:
+  - make
+
 jobs:
-  - &copr
-    job: copr_build
-    # Run on every PR
+  - job: copr_build
     trigger: pull_request
-    owner: rhcontainerbot
-    project: packit-builds
     enable_net: true
-    # x86_64 is assumed by default
     # container-selinux is noarch so we only need to test on one arch
     targets: &pr_copr_targets
       - fedora-all
       - centos-stream-9
       - centos-stream-8
-    srpm_build_deps:
-      - make
 
-  - <<: *copr
-    # Run on commit to main branch
+  # Run on commit to main branch
+  - job: copr_build
     trigger: commit
     branch: main
+    owner: rhcontainerbot
     project: podman-next
-    targets:
-      - fedora-all-aarch64
-      - fedora-all-ppc64le
-      - fedora-all-s390x
-      - fedora-all-x86_64
-      - centos-stream+epel-next-9-aarch64
-      - centos-stream+epel-next-9-ppc64le
-      - centos-stream+epel-next-9-s390x
-      - centos-stream+epel-next-9-x86_64
+    enable_net: true
 
   # All tests specified in the `/plans/` subdir
   # FIXME: uncomment e2e tests after disk space issues resolved on testing farm


### PR DESCRIPTION
Building all PRs of all container projects into the same COPR does not properly isolate PRs from each other: E.g. a podman PR currently runs against whichever container-selinux PR was opened/updated last; in other words, sending a broken container-selinux PR will instantly break tests for all subsequent podman runs.

To avoid that, change the copr_build configuration to use the packit default COPRs, which are specific to the particular PR, and disappear after a few weeks. Depending projects like podman should only run against what landed in container-selinux/main, i.e. the podman-next COPR.

Note that this does not preclude testing a podman PR against an container-selinux PR: This can be explicitly requested [1]. But most PRs don't change the API and thus should default to isolation.

In addition, drop the explicit target list for podman-next. If it differs from the actually configured target list in COPR, it will either fail (if the packit user wasn't granted admin rights), or actually reconfigure the COPR -- neither is desirable.

[1] https://packit.dev/posts/testing-farm-triggering

----

This is exactly the same as https://github.com/containers/crun/pull/1260 ; please see the discussion there, this change needs to be applied to all container projects, and then all land together. Let's keep all the relevant discussions and tracking in  the crun PR please.