### PR TITLE
give containers access to pod resources endpoint

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -126,6 +126,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 
 /var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
+/var/lib/kubelet/pod-resources/kubelet.sock		gen_context(system_u:object_r:container_file_t,s0)
 /var/lib/docker-latest(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)


### PR DESCRIPTION
from the kubelet's perspective, this endpoint is read only--a process cannot change anything in the kubelet by accessing it.

Since access to these files will be prevented by kubernetes security policy (eliminating the vector of malicious snooping), I think it will be safe to allow containers rw access to this socket.

Fixes https://issues.redhat.com/browse/RHEL-3128