### PR TITLE
Packit: enable centos testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,6 +21,8 @@ jobs:
       - fedora-eln
       - epel-9
       - epel-8
+    additional_repos:
+      - "copr://rhcontainerbot/podman-next"
 
   # Run on commit to main branch
   - job: copr_build
@@ -41,8 +43,7 @@ jobs:
         message: "podman e2e tests failed. @containers/packit-build please check."
     targets: &pr_test_targets
       - fedora-all
-        # TODO: re-enable these once https://github.com/containers/podman/pull/20262 is merged.
-        #- epel-9
+      - epel-9
         #- epel-8
     identifier: podman_e2e_test
     tmt_plan: "/plans/podman_e2e_test"

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,18 +1,20 @@
+adjust:
+#    - when: "distro >= rhel-8 or distro >= centos-stream-8"
+#      because: "Need bats from epel"
+#      prepare:
+#        - how: install
+#          package: epel-release
+    - when: "distro == rhel-8 or distro == centos-stream-8"
+      because: "Need to test with latest podman"
+      prepare:
+        - how: shell
+          script: dnf -y module disable container-tools
+    
 prepare:
-    - name: Disable testing-farm dnf repos
-      how: shell
-      script: |
-        if [ $(rpm --eval %{rhel}) <= 8 ]; then
-            echo "Disabling container-tools module..."
-            dnf -y module disable container-tools
-        fi
-        if [[ ! -f /etc/redhat-release || $(rpm --eval %{?fedora}) > 37 ]]; then
-            echo "Disabling testing-farm-tag-repository dnf repo for F38+..."
-            dnf config-manager --disable testing-farm-tag-repository
-        fi
-    - name: Install packages
-      how: install
-      copr: rhcontainerbot/podman-next
+    # Ensure copr has higher priority over default repos
+    - how: shell
+      script: dnf -y config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"
+    - how: install
       package:
         - bats
         - golang


### PR DESCRIPTION
TMT recognizes the `epel-N` target, so we mention the epel targets in packit config for centos testing.