### PR TITLE
label kubensenter as well as kubenswrapper

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -11,6 +11,8 @@
 /usr/local/s?bin/hyperkube.*		--	gen_context(system_u:object_r:kubelet_exec_t,s0)
 /usr/s?bin/kubenswrapper.*		--	gen_context(system_u:object_r:kubelet_exec_t,s0)
 /usr/local/s?bin/kubenswrapper.*	--	gen_context(system_u:object_r:kubelet_exec_t,s0)
+/usr/s?bin/kubensenter.*		--	gen_context(system_u:object_r:kubelet_exec_t,s0)
+/usr/local/s?bin/kubensenter.*	--	gen_context(system_u:object_r:kubelet_exec_t,s0)
 /usr/local/s?bin/docker.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/s?bin/containerd.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)
 /usr/local/s?bin/containerd.*		--	gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
on openshift, kubenswrapper service calls kubensenter, which calls the kubelet. Without this change, kubelet will continue to be labeled unconfined_t