### PR TITLE
Label kata-containers assets

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -162,3 +162,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/log/lxc(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/lxd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /etc/kubernetes(/.*)?		gen_context(system_u:object_r:kubernetes_file_t,s0)
+
+/opt/kata/bin(/.*)?		gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/opt/kata/libexec(/.*)?		gen_context(system_u:object_r:container_runtime_exec_t,s0)
+/opt/kata/runtime-rs/bin(/.*)?	gen_context(system_u:object_r:container_runtime_exec_t,s0)


### PR DESCRIPTION
The https://github.com/kata-containers/kata-containers/ project stores required binary files (like qemu, virtfsd, ...) into /opt/kata/ allow it's execution by labeling them appropriately.

Note this is for the upstream kata-containers, the RH downstream one uses system built-in binaries. More details are available in the kata-issue https://github.com/kata-containers/kata-containers/pull/8417