### PR TITLE
Allow access to BPF Filesystems

### DIFF
--- a/container.te
+++ b/container.te
@@ -1125,6 +1125,8 @@ storage_rw_fuse(container_domain)
 allow container_domain fusefs_t:file { mounton execmod };
 allow container_domain fusefs_t:filesystem remount;
 
+fs_manage_bpf_files(container_domain)
+
 tunable_policy(`virt_sandbox_use_netlink',`
 	allow container_domain self:netlink_socket create_socket_perms;
 	allow container_domain self:netlink_tcpdiag_socket create_netlink_socket_perms;


### PR DESCRIPTION
BPF Filesystems (bpffs) are used to manage BPF Object Lifecycles. For example, you can place a special object (called a pin) on a BPF filesystem and use that object to get a reference to the program/link/map that it references if you have permissions to make bpf() syscalls.

In a recent kernel patch, a container may also recieve a token that allows it to make BPF syscalls on this filesystem.

Since bpffs doesn't support xattrs, it's not possible to bind mount it from the host with `:Z` so it can be re-labelled. Adding xattrs to bpffs is not something that I've looked into in detail, but I imagine it's non-trivial.

This commit should add the necessary rules to ensure that SELinux permits the use of bpf_t file/directory objects from containers when the BPFFS volume was bind mounted from the host.