### PR TITLE
TMT: reorganize tests into scripts

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -67,9 +67,9 @@ jobs:
         message: "podman e2e tests failed on RHEL. @containers/packit-build please check."
     targets: &pr_test_targets_rhel
       epel-9-x86_64:
-        distros: [RHEL-9.3.0-Nightly,RHEL-9.4.0-Nightly]
+        distros: [RHEL-9.4.0-Nightly,RHEL-9-Nightly]
       epel-8-x86_64:
-        distros: [RHEL-8.9.0-Nightly,RHEL-8.10.0-Nightly]
+        distros: [RHEL-8.9.0-Nightly,RHEL-8-Nightly]
     identifier: podman_e2e_test_internal
     tmt_plan: "/plans/podman_e2e_test"
 

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -6,29 +6,9 @@ adjust:
 
 prepare:
     - how: shell
-      script: |
-        RHEL_RELEASE=$(rpm --eval %{?rhel})
-        ARCH=$(uname -m)
-        if [ $RHEL_RELEASE -eq 8 ]; then
-            echo "Disabling container-tools module..."
-            dnf -y module disable container-tools
-            # FIXME: remove this after crun is correctly built for the epel-8-*
-            # targets on podman-next copr
-            dnf -y install https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/centos-stream+epel-next-8-$ARCH/07097739-crun/crun-1.14.4-1.20240302220834691516.main.10.g64ee22c.el8.$ARCH.rpm
-        fi
-        if [ -f /etc/centos-release ]; then
-            echo "Installing epel-release..."
-            dnf -y install epel-release
-        elif [ $RHEL_RELEASE -ge 8 ]; then
-            echo "Installing epel-release..."
-            dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$RHEL_RELEASE.noarch.rpm
-            echo "Enabling epel repo..."
-            dnf config-manager --set-enabled epel
-            cat /etc/yum.repos.d/epel.repo
-        fi
-        dnf -y copr enable rhcontainerbot/podman-next
-        dnf config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"
+      script: bash ./plans/prepare.sh
     - how: install
+      copr: rhcontainerbot/podman-next
       package:
         - bats
         - golang
@@ -39,32 +19,10 @@ prepare:
     summary: Run SELinux specific Podman e2e tests
     execute:
         how: tmt
-        script: |
-            echo "Checking /etc/redhat-release..."
-            cat /etc/redhat-release
-            echo "Checking installed versions of required packages..."
-            rpm -q container-selinux golang podman
-            if [ -f /etc/fedora-release ]; then
-                echo "Resizing tmpfs..."
-                mount -o remount,size=10G /tmp
-            fi
-            echo "Fetching podman srpm from copr..."
-            dnf --disablerepo=* --enablerepo=copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next download --source podman
-            echo "Extracting podman source from srpm..."
-            rpm2cpio podman*.src.rpm | cpio -di
-            tar zxf podman-*-dev.tar.gz
-            echo "Running podman e2e tests..."
-            cd podman-*-dev/test/e2e
-            PODMAN_BINARY=/usr/bin/podman go test -v config.go config_amd64.go common_test.go libpod_suite_test.go run_selinux_test.go
+        script: bash ./plans/podman_e2e_test.sh
 
 /podman_system_test:
     summary: Run SELinux specific Podman system tests
     execute:
         how: tmt
-        script: |
-            echo "Checking /etc/redhat-release..."
-            cat /etc/redhat-release
-            echo "Checking installed versions of required packages..."
-            rpm -q container-selinux podman podman-tests
-            echo "Running podman system tests..."
-            bats /usr/share/podman/test/system/410-selinux.bats
+        script: bash ./plans/podman_system_test.sh

--- a/plans/podman_e2e_test.sh
+++ b/plans/podman_e2e_test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+cat /etc/redhat-release
+rpm -q container-selinux golang podman
+if [[ -f /etc/fedora-release ]]; then
+    export TMPDIR=/var/tmp
+fi
+dnf --disablerepo=* --enablerepo=copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next download --source podman
+rpm2cpio podman*.src.rpm | cpio -di
+tar zxf podman-*-dev.tar.gz
+cd podman-*-dev/test/e2e
+PODMAN_BINARY=/usr/bin/podman go test -v config.go config_amd64.go common_test.go libpod_suite_test.go run_selinux_test.go

--- a/plans/podman_system_test.sh
+++ b/plans/podman_system_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+cat /etc/redhat-release
+rpm -q container-selinux podman podman-tests
+bats /usr/share/podman/test/system/410-selinux.bats

--- a/plans/prepare.sh
+++ b/plans/prepare.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+RHEL_RELEASE=$(rpm --eval '%{?rhel}')
+ARCH=$(uname -m)
+
+if [[ $RHEL_RELEASE -eq 8 ]]; then
+    # EL8 has container-tools enabled by default causing installation issues
+    # with podman-next copr packages
+    dnf -y module disable container-tools
+    # FIXME: remove this after crun is correctly built for the epel-8-*
+    # targets on podman-next copr
+    dnf -y install https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/centos-stream+epel-next-8-$ARCH/07097739-crun/crun-1.14.4-1.20240302220834691516.main.10.g64ee22c.el8.$ARCH.rpm
+fi
+if [[ -f /etc/centos-release ]]; then
+    dnf -y install epel-release
+elif [[ $RHEL_RELEASE -ge 8 ]]; then
+    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$RHEL_RELEASE.noarch.rpm
+    dnf config-manager --set-enabled epel
+fi
+dnf -y copr enable rhcontainerbot/podman-next
+dnf config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"


### PR DESCRIPTION
This commit also reorganizes individual tests in scripts so they can be executed standalone if need be.

The RHEL targets are also updated to use more generic floating targets wherever possible.