### PR TITLE
Packit/TMT: enable downstream syncing to CentOS Stream 10

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,8 +2,16 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: rpm/container-selinux.spec
+downstream_package_name: container-selinux
 upstream_tag_template: v{version}
+
+packages:
+  container-selinux-fedora:
+    pkg_tool: fedpkg
+    specfile_path: rpm/container-selinux.spec
+  container-selinux-centos:
+    pkg_tool: centpkg
+    specfile_path: rpm/container-selinux.spec
 
 srpm_build_deps:
   - make
@@ -11,7 +19,8 @@ srpm_build_deps:
 jobs:
   - job: copr_build
     trigger: pull_request
-    notifications:
+    packages: [container-selinux-fedora]
+    notifications: &copr_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
@@ -19,7 +28,17 @@ jobs:
     targets:
       - fedora-all
       - fedora-eln
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [container-selinux-centos]
+    notifications: *copr_build_failure_notification
+    enable_net: true
+    targets:
+      # We run both epel (based on rhel) and centos stream builds so that we can use the respective rpms to
+      # runs tests on each environment.
       - epel-9
+      - centos-stream-9
       - centos-stream-10
 
   # Run on commit to main branch
@@ -35,50 +54,72 @@ jobs:
     enable_net: true
 
   # All tests specified in the `/plans/` subdir
-  # Podman e2e tests for Fedora and CentOS Stream
+  # Podman e2e tests for Fedora
   - job: tests
     trigger: pull_request
-    notifications:
+    packages: [container-selinux-fedora]
+    notifications: &e2e_test_failure_notification
       failure_comment:
         message: "podman e2e tests failed. @containers/packit-build please check."
-    targets: &pr_test_targets
+    targets: &pr_test_targets_fedora
       - fedora-all
-      - epel-9
-      # TODO: Enable cs10, rhel10 tests once netavark defaults to nftablesthere's
-      #- centos-stream-10
-    identifier: podman_e2e_test
+    identifier: podman_e2e_test_fedora
     tmt_plan: "/plans/podman_e2e_test"
 
-  # Podman system tests for Fedora and CentOS Stream
+  # Podman e2e tests for CentOS Stream
   - job: tests
     trigger: pull_request
-    notifications:
+    packages: [container-selinux-centos]
+    notifications: *e2e_test_failure_notification
+    targets: &pr_test_targets_centos
+      - centos-stream-9
+      # TODO: enable these after netavark defaults have been resolved on rhel10
+      #- centos-stream-10
+    identifier: podman_e2e_test_centos
+    tmt_plan: "/plans/podman_e2e_test"
+
+  # Podman system tests for Fedora
+  - job: tests
+    trigger: pull_request
+    packages: [container-selinux-fedora]
+    notifications: &system_test_failure_notification
       failure_comment:
         message: "podman system tests failed. @containers/packit-build please check."
-    targets: *pr_test_targets
+    targets: *pr_test_targets_fedora
     identifier: podman_system_test
+    tmt_plan: "/plans/podman_system_test"
+
+  # Podman system tests for CentOS Stream
+  - job: tests
+    trigger: pull_request
+    packages: [container-selinux-centos]
+    notifications: *system_test_failure_notification
+    targets: *pr_test_targets_centos
+    identifier: podman_system_test_centos
     tmt_plan: "/plans/podman_system_test"
 
   # Podman e2e tests for RHEL
   - job: tests
     trigger: pull_request
+    packages: [container-selinux-centos]
     use_internal_tf: true
-    notifications:
-      failure_comment:
-        message: "podman e2e tests failed on RHEL. @containers/packit-build please check."
+    notifications: *e2e_test_failure_notification
     targets: &pr_test_targets_rhel
       epel-9-x86_64:
         distros: [RHEL-9.4.0-Nightly,RHEL-9-Nightly]
+      # Use centos-stream-10 until we have epel-10
+      # TODO: enable these after netavark defaults have been resolved on rhel10
+      #centos-stream-10-x86_64:
+      #  distros: [RHEL-10-Beta-Nightly]
     identifier: podman_e2e_test_internal
     tmt_plan: "/plans/podman_e2e_test"
 
   # Podman system tests for RHEL
   - job: tests
     trigger: pull_request
+    packages: [container-selinux-centos]
     use_internal_tf: true
-    notifications:
-      failure_comment:
-        message: "podman system tests failed on RHEL. @containers/packit-build please check."
+    notifications: *system_test_failure_notification
     targets: *pr_test_targets_rhel
     identifier: podman_system_test_internal
     tmt_plan: "/plans/podman_system_test"
@@ -86,15 +127,25 @@ jobs:
   - job: propose_downstream
     trigger: release
     update_release: false
+    packages: [container-selinux-fedora]
     dist_git_branches:
       - fedora-all
 
+  - job: propose_downstream
+    trigger: release
+    update_release: false
+    packages: [container-selinux-centos]
+    dist_git_branches:
+      - c10s
+
   - job: koji_build
     trigger: commit
+    packages: [container-selinux-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: bodhi_update
     trigger: commit
+    packages: [container-selinux-fedora]
     dist_git_branches:
       - fedora-branched # rawhide updates are created automatically

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -15,13 +15,13 @@ adjust:
           order: 20
           script:  dnf config-manager --set-disabled testing-farm-tag-repository
       because: We don't want to use this repository for Fedora tests.
-    - when: distro != centos-stream-10
+    - when: distro != centos-stream-10 && distro != rhel-10
       prepare+:
         - how: shell
           order: 30
           script: dnf -y copr enable rhcontainerbot/podman-next
       because: We can't use the idiomatic `copr` key globally because of non-default instructions for centos-stream-10.
-    - when: distro == centos-stream-10
+    - when: distro == centos-stream-10 or distro == rhel-10
       prepare+:
         - how: shell
           order: 30

--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -21,9 +21,14 @@
 %define no_user_namespace 1
 %endif
 
+# copr_build is more intuitive than copr_username
+%if %{defined copr_username}
+%define copr_build 1
+%endif
+
 Name: container-selinux
 # Set different Epochs for copr and koji
-%if %{defined copr_username}
+%if %{defined copr_build}
 Epoch: 102
 %else
 Epoch: 2


### PR DESCRIPTION
This commit enables downstream syncing to CentOS Stream 10. This isn't fully automated yet and requires the maintainer to run `packit propse-downstream` and `centpkg build` steps manually.

This commit also adds TMT podman revdep tests for CentOS Stream 10 and RHEL 10 Beta Nightly. These tests are likely to fail pending netavark work to default to nftables.

This commit will also run separate jobs for `epel-9` and `centos-stream-9` to ensure we're using rhel rpms for rhel tests and centos stream rpms for centos stream tests. This will also be done for centos stream 10 / rhel 10 once the epel-10 target is created on copr.