### PR TITLE
Packit and TMT fixes

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,8 @@ packages:
   container-selinux-centos:
     pkg_tool: centpkg
     specfile_path: rpm/container-selinux.spec
+  container-selinux-rhel:
+    specfile_path: rpm/container-selinux.spec
 
 srpm_build_deps:
   - make
@@ -35,16 +37,22 @@ jobs:
     notifications: *copr_build_failure_notification
     enable_net: true
     targets:
-      # We run both epel (based on rhel) and centos stream builds so that we can use the respective rpms to
-      # runs tests on each environment.
-      - epel-9
       - centos-stream-9
       - centos-stream-10
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [container-selinux-rhel]
+    notifications: *copr_build_failure_notification
+    enable_net: true
+    targets:
+      - epel-9
 
   # Run on commit to main branch
   # Build targets managed in copr settings
   - job: copr_build
     trigger: commit
+    packages: [container-selinux-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."
@@ -101,7 +109,7 @@ jobs:
   # Podman e2e tests for RHEL
   - job: tests
     trigger: pull_request
-    packages: [container-selinux-centos]
+    packages: [container-selinux-rhel]
     use_internal_tf: true
     notifications: *e2e_test_failure_notification
     targets: &pr_test_targets_rhel
@@ -117,7 +125,7 @@ jobs:
   # Podman system tests for RHEL
   - job: tests
     trigger: pull_request
-    packages: [container-selinux-centos]
+    packages: [container-selinux-rhel]
     use_internal_tf: true
     notifications: *system_test_failure_notification
     targets: *pr_test_targets_rhel

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,41 +1,36 @@
-## Note: "order" is set to 50 by default. Orders with lower values are
-## prioritized.
-## Ref: https://tmt.readthedocs.io/en/stable/spec/core.html#order
+prepare+:
+    - name: Install bats
+      how: shell
+      script: |
+        BATS_VERSION=1.11.0
+        curl -s -L -O https://github.com/bats-core/bats-core/archive/refs/tags/v$BATS_VERSION.tar.gz
+        tar zxf v$BATS_VERSION.tar.gz
+        cd bats-core-$BATS_VERSION
+        ./install.sh /usr
 
-adjust:
-    - when: distro != fedora
-      prepare+:
-        - how: shell
-          order: 20
-          script: rpm -q bats || dnf -y install https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/b/bats-1.8.0-1.el9.noarch.rpm https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/p/parallel-20230822-1.el9.noarch.rpm
-      because: Need `bats` to run podman system tests, present by default on Fedora but EL needs to use EPEL repos.
-    - when: distro == fedora
-      prepare+:
-        - how: shell
-          order: 20
-          script:  dnf config-manager --set-disabled testing-farm-tag-repository
-      because: We don't want to use this repository for Fedora tests.
-    - when: distro != centos-stream-10 && distro != rhel-10
-      prepare+:
-        - how: shell
-          order: 30
-          script: dnf -y copr enable rhcontainerbot/podman-next
-      because: We can't use the idiomatic `copr` key globally because of non-default instructions for centos-stream-10.
-    - when: distro == centos-stream-10 or distro == rhel-10
-      prepare+:
-        - how: shell
-          order: 30
-          script: dnf -y copr enable rhcontainerbot/podman-next centos-stream-10
-      because: The default epel-10 target doesn't exist yet.
+    - name: Remove testing-farm dnf repo
+      how: shell
+      script: rm -f /etc/yum.repos.d/testing-farm-tag-repository.repo
 
-prepare:
-    # Ensure podman-next has higher priority than default repos
-    - how: shell
-      script: dnf config-manager --save --setopt="*:rhcontainerbot:podman-next.priority=5"
+    - name: Enable podman-next repo and set it at higher priority than default
+      how: shell
+      script: |
+        CENTOS_VERSION=$(rpm --eval '%{?centos}')
+        RHEL_VERSION=$(rpm --eval '%{?rhel}')
+        if [[ -n $CENTOS_VERSION ]]; then
+            dnf -y copr enable rhcontainerbot/podman-next centos-stream-$CENTOS_VERSION
+        # Need to handle RHEL-10 specially until EPEL-10 is available
+        elif [[ $RHEL_VERSION -ge 10 ]]; then
+            dnf -y copr enable rhcontainerbot/podman-next centos-stream-$RHEL_VERSION
+        else
+            dnf -y copr enable rhcontainerbot/podman-next
+        fi
+        # Bump podman-next copr priority
+        echo "priority=5" >> /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next.repo
+
     # Install packages to run podman revdep tests
     - how: install
       package:
-        - bats
         - golang
         - podman
         - podman-tests

--- a/plans/podman_e2e_test.sh
+++ b/plans/podman_e2e_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -exo pipefail
+# Do not set -e as we want to work on all results of `rpm -q dnf[5]`.
+set -xo pipefail
 
 cat /etc/redhat-release
 rpm -q container-selinux golang podman
@@ -8,8 +9,21 @@ rpm -q container-selinux golang podman
 # /tmp is often unsufficient
 export TMPDIR=/var/tmp
 
+# dnf5 contains breaking changes
+# Either of `dnf` OR `dnf5` will be installed, never both.
+# To fetch srpm, dnf uses `--source`, dnf5 uses `--srpm`.
+rpm -q dnf5
+if [[ $? -eq 0 ]]; then
+    SRPM_OPTS="--srpm"
+else
+    SRPM_OPTS="--source"
+fi
+
 # Fetch and extract latest podman source from podman-next copr
-dnf --disablerepo=* --enablerepo=copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next download --source podman
+# NOTE: The TMT preparation set podman-next copr to the highest priority so we
+# shouldn't need to manipulate any dnf repos here but just fetch from what's
+# already set.
+dnf download $SRPM_OPTS podman
 rpm2cpio podman*.src.rpm | cpio -di
 tar zxf podman-*-dev.tar.gz
 


### PR DESCRIPTION
Commit 1: Minimize distro conditionals

Differences across distros and versions in components like dnf as well as variable package availability for bats makes idiomatic TMT hard to maintain if we're to install all dependencies using rpm packages.

Fetching `bats` from upstream and simply deleting problematic yum repos instead of resorting to tricky dnf commands makes the TMT logic a lot easier to maintain.


Commit 2: Packit: separate out rhel and centos stream tasks
    
This enables centos-stream jobs to run automatically on all PRs regardless of the PR author's access level on the repo. RHEL tests on PRs by non-maintainers would need manual triggereing by maintainers.
  
This also adds `packages: [container-selinux-fedora]` key value to the `trigger: commit` build job to avoid duplicate build jobs on podman-next copr after every commit to main.

