### PR TITLE
Packit: remove `update_release` key from downstream jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -113,14 +113,12 @@ jobs:
 
   - job: propose_downstream
     trigger: release
-    update_release: false
     packages: [container-selinux-fedora]
     dist_git_branches:
       - fedora-all
 
   - job: propose_downstream
     trigger: release
-    update_release: false
     packages: [container-selinux-centos]
     dist_git_branches:
       - c10s


### PR DESCRIPTION
`update_release` is useless in downstream. FWIW, it's also not desirable for upstream / copr jobs.