### PR TITLE
TMT: Simplify tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,7 @@ upstream_tag_template: v{version}
 files_to_sync:
   - src: rpm/gating.yaml
     dest: gating.yaml
+    delete: true
   - src: plans/
     dest: plans/
     delete: true
@@ -51,7 +52,7 @@ jobs:
     packages: [container-selinux-centos]
     notifications: *copr_build_failure_notification
     enable_net: true
-    targets:
+    targets: &centos_targets
       - centos-stream-9
       - centos-stream-10
 
@@ -86,15 +87,23 @@ jobs:
         message: "Tests failed. @containers/packit-build please check."
     targets:
       - fedora-all
+    tf_extra_params:
+      environments:
+        - artifacts:
+          - type: repository-file
+            id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-$releasever/rhcontainerbot-podman-next-fedora-$releasever.repo
 
   # Tests for CentOS Stream
   - job: tests
     trigger: pull_request
     packages: [container-selinux-centos]
     notifications: *test_failure_notification
-    targets:
-      - centos-stream-9
-      - centos-stream-10
+    targets: *centos_targets
+    tf_extra_params:
+      environments:
+        - artifacts:
+          - type: repository-file
+            id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/centos-stream-$releasever/rhcontainerbot-podman-next-centos-stream-$releasever.repo
 
   # Tests for RHEL
   - job: tests
@@ -105,11 +114,13 @@ jobs:
     targets:
       epel-9-x86_64:
         distros: [RHEL-9.4.0-Nightly,RHEL-9-Nightly]
-      # Use centos-stream-10 until we have epel-10
-      # TODO: Enable after RHEL-10 gets selinux-policy >= 40.13.1 which is
-      # already on CentOS Stream 10.
-      #centos-stream-10-x86_64:
-        #  distros: [RHEL-10-Beta-Nightly]
+    tf_extra_params:
+      environments:
+        - artifacts:
+          - type: repository-file
+            id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/epel-$releasever/rhcontainerbot-podman-next-epel-$releasever.repo
+          - type: repository-file
+            id: https://src.fedoraproject.org/rpms/epel-release/raw/epel9/f/epel.repo
 
   - job: propose_downstream
     trigger: release

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -12,7 +12,7 @@ execute:
         when: initiator is not defined or initiator != packit
 
 /downstream:
-    summary: Run SELinux specific Podman e2e tests on bodhi / errata and dist-git PRs
+    summary: Run SELinux specific Podman tests on bodhi / errata and dist-git PRs
     discover+:
         filter: tag:downstream
     adjust+:

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,21 +3,13 @@ basic_check:
 	semodule --list=full | grep container
 	semodule -B
 
-.PHONY: podman_e2e_test_upstream
-podman_e2e_test_upstream:
-	bash ./podman-tests.sh e2e upstream
+.PHONY: podman_e2e_test
+podman_e2e_test:
+	bash ./podman-tests.sh e2e
 
-.PHONY: podman_e2e_test_downstream
-podman_e2e_test_downstream:
-	bash ./podman-tests.sh e2e downstream
-
-.PHONY: podman_system_test_upstream
-podman_system_test_upstream:
-	bash ./podman-tests.sh system upstream
-
-.PHONY: podman_system_test_downstream
-podman_system_test_downstream:
-	bash ./podman-tests.sh system downstream
+.PHONY: podman_system_test
+podman_system_test:
+	bash ./podman-tests.sh system
 
 clean:
 	rm -rf podman-*dev* podman.spec

--- a/test/main.fmf
+++ b/test/main.fmf
@@ -6,24 +6,16 @@ require:
     - policycoreutils
 
 /basic_check:
-    summary: Run basic checks
     tag: [ upstream, downstream ]
+    summary: Run basic checks
     test: make basic_check
 
-/upstream:
-    tag: upstream
-/upstream/podman_e2e_test:
-    summary: Run SELinux specific Podman e2e tests on upstream PRs
-    test: make podman_e2e_test_upstream
-/upstream/podman_system_test:
-    summary: Run SELinux specific Podman system tests on upstream PRs
-    test: make podman_system_test_upstream
+/podman_e2e_test:
+    tag: [ upstream, downstream ]
+    summary: Run SELinux specific Podman e2e tests
+    test: make podman_e2e_test
 
-/downstream:
-    tag: downstream
-/downstream/podman_e2e_test:
-    summary: Run SELinux specific Podman e2e tests on downstream bodhi / errata and dist-git PRs
-    test: make podman_e2e_test_downstream
-/downstream/podman_system_test:
-    summary: Run SELinux specific Podman system tests on downstream bodhi / errata and dist-git PRs
-    test: make podman_system_test_downstream
+/podman_system_test:
+    tag: [ upstream, downstream ]
+    summary: Run SELinux specific Podman system tests
+    test: make podman_system_test


### PR DESCRIPTION
This commit moves a lot of the copr and epel repo enablement in the test environment from shell script to idiomatic packit.