### PR TITLE
RPM: cleanup changelog

### DIFF
--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -137,12 +137,4 @@ if %{_sbindir}/selinuxenabled ; then
 fi
 
 %changelog
-%if %{defined autochangelog}
 %autochangelog
-%else
-# NOTE: This changelog will be visible on CentOS 8 Stream builds
-# Other envs are capable of handling autochangelog
-* Tue Jun 13 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>
-- Placeholder changelog for envs that are not autochangelog-ready.
-- Contact upstream if you need to report an issue with the build.
-%endif


### PR DESCRIPTION
All of Fedora and CentOS Stream 10 have autochangelog support so we don't need the changelog conditionals.