### PR TITLE
change label of kubelet's socket to kubernetes_file_t

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -131,7 +131,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 
 /var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
-/var/lib/kubelet/pod-resources/kubelet.sock		gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/kubelet/pod-resources/kubelet.sock		gen_context(system_u:object_r:kubernetes_file_t,s0)
 /var/lib/docker-latest(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/docker-latest/.*/config\.env	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker-latest/containers/.*/.*\.log	gen_context(system_u:object_r:container_log_t,s0)

--- a/container.te
+++ b/container.te
@@ -1483,6 +1483,8 @@ application_executable_file(kubelet_exec_t)
 can_exec(container_runtime_t, kubelet_exec_t)
 allow kubelet_t kubelet_exec_t:file entrypoint;
 
+container_lib_filetrans(kubelet_t, kubernetes_file_t, sock_file, "kubelet.sock")
+
 ifdef(`enable_mcs',`
 	init_ranged_daemon_domain(kubelet_t, kubelet_exec_t, s0 - mcs_systemhigh)
 ')


### PR DESCRIPTION
This commit is a continuation of https://github.com/containers/container-selinux/pull/275/files.

When Kubelet starts it creates `/var/lib/kubelet/pod-resources/kubelet.sock` file on the fly. This means the socket file inheret its type from the parent so it still gets the `container_var_lib_t` type.

We're adding the `container_lib_filetrans` in order to change the socket to the correct label.