### PR TITLE
dontaudit spc_t to mmap_zero

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.233.0)
+policy_module(container, 2.234.0)
 
 gen_require(`
 	class passwd rootok;
@@ -757,6 +757,7 @@ tunable_policy(`container_connect_any',`
 #
 allow spc_t { container_file_t container_var_lib_t container_ro_file_t container_runtime_tmpfs_t}:file entrypoint;
 role system_r types spc_t;
+dontaudit spc_t self:memprotect mmap_zero;
 
 domtrans_pattern(container_runtime_domain, container_ro_file_t, spc_t)
 domtrans_pattern(container_runtime_domain, container_var_lib_t, spc_t)


### PR DESCRIPTION
For some apps running under docker, docker attempts emulation mode triggering this AVC.

No reason to now allow it.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2297712