### PR TITLE
Packit: update targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,6 +30,8 @@ packages:
     specfile_path: rpm/container-selinux.spec
   container-selinux-rhel:
     specfile_path: rpm/container-selinux.spec
+  container-selinux-eln:
+    specfile_path: rpm/container-selinux.spec
 
 srpm_build_deps:
   - make
@@ -43,8 +45,18 @@ jobs:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
     enable_net: true
     # container-selinux is noarch so we only need to test on one arch
+    targets: &fedora_copr_targets
+      - fedora-development
+      - fedora-latest
+      - fedora-ltest-stable
+      - fedora-40
+
+  - job: copr_build
+    trigger: pull_request
+    packages: [container-selinux-eln]
+    notifications: *copr_build_failure_notification
+    enable_net: true
     targets:
-      - fedora-all
       - fedora-eln
 
   - job: copr_build
@@ -52,7 +64,7 @@ jobs:
     packages: [container-selinux-centos]
     notifications: *copr_build_failure_notification
     enable_net: true
-    targets: &centos_targets
+    targets: &centos_copr_targets
       - centos-stream-9
       - centos-stream-10
 
@@ -85,8 +97,7 @@ jobs:
     notifications: &test_failure_notification
       failure_comment:
         message: "Tests failed. @containers/packit-build please check."
-    targets:
-      - fedora-all
+    targets: *fedora_copr_targets
     tf_extra_params:
       environments:
         - artifacts:
@@ -98,34 +109,35 @@ jobs:
     trigger: pull_request
     packages: [container-selinux-centos]
     notifications: *test_failure_notification
-    targets: *centos_targets
+    targets: *centos_copr_targets
     tf_extra_params:
       environments:
         - artifacts:
           - type: repository-file
             id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/centos-stream-$releasever/rhcontainerbot-podman-next-centos-stream-$releasever.repo
 
+  # FIXME: Re-enable once podman packit copr builds are re-enabled for el9
   # Tests for RHEL
-  - job: tests
-    trigger: pull_request
-    packages: [container-selinux-rhel]
-    use_internal_tf: true
-    notifications: *test_failure_notification
-    targets:
-      epel-9-x86_64:
-        distros: [RHEL-9.4.0-Nightly,RHEL-9-Nightly]
-    tf_extra_params:
-      environments:
-        - artifacts:
-          - type: repository-file
-            id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/epel-$releasever/rhcontainerbot-podman-next-epel-$releasever.repo
-          - type: repository-file
-            id: https://src.fedoraproject.org/rpms/epel-release/raw/epel9/f/epel.repo
+  #- job: tests
+  #  trigger: pull_request
+  #  packages: [container-selinux-rhel]
+  #  use_internal_tf: true
+  #  notifications: *test_failure_notification
+  #  targets:
+  #    epel-9-x86_64:
+  #      distros: [RHEL-9.4.0-Nightly,RHEL-9-Nightly]
+  #  tf_extra_params:
+  #    environments:
+  #      - artifacts:
+  #        - type: repository-file
+  #          id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/epel-$releasever/rhcontainerbot-podman-next-epel-$releasever.repo
+  #        - type: repository-file
+  #          id: https://src.fedoraproject.org/rpms/epel-release/raw/epel9/f/epel.repo
 
   - job: propose_downstream
     trigger: release
     packages: [container-selinux-fedora]
-    dist_git_branches:
+    dist_git_branches: &fedora_targets
       - fedora-all
 
   - job: propose_downstream
@@ -137,8 +149,7 @@ jobs:
   - job: koji_build
     trigger: commit
     packages: [container-selinux-fedora]
-    dist_git_branches:
-      - fedora-all
+    dist_git_branches: *fedora_targets
 
   - job: bodhi_update
     trigger: commit


### PR DESCRIPTION
This commit removes f39 from the copr jobs and disables el9 podman revdep test jobs as we recently disabled f39 and el9 jobs on the podman-next copr due to golang 1.22 bump for our golang projects.
    
The copr and dist-git targets are also reused with yaml anchors wherever possible.
