### PR TITLE
set container_log_t type for /var/log/kube-apiserver

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -162,6 +162,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 
 /run/lock/lxc(/.*)?		gen_context(system_u:object_r:container_lock_t,s0)
 
+/var/log/kube-apiserver(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/lxc(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/lxd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /etc/kubernetes(/.*)?		gen_context(system_u:object_r:kubernetes_file_t,s0)

--- a/container.if
+++ b/container.if
@@ -512,6 +512,7 @@ interface(`container_filetrans_named_content',`
     files_pid_filetrans($1, container_var_run_t, dir, "containers")
     files_pid_filetrans($1, container_kvm_var_run_t, dir, "kata-containers")
 
+    logging_log_filetrans($1, container_log_t, dir, "kube-apiserver")
     logging_log_filetrans($1, container_log_t, dir, "lxc")
     files_var_lib_filetrans($1, container_var_lib_t, dir, "containers")
     files_var_lib_filetrans($1, container_file_t, dir, "origin")


### PR DESCRIPTION
No type was being set for this directory so it ended up inheriting the type for /var/log causing testing failures in microshift environments on upgrade from rhel 9.3 to 9.4.