### PR TITLE
RPM: explicitly list ghosted paths and skip mode verification

### DIFF
--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -128,7 +128,8 @@ fi
 # Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2209120
 #%%{_mandir}/man8/container_selinux.8.gz
 %{_sysconfdir}/selinux/targeted/contexts/users/container_u
-%ghost %{_sharedstatedir}/selinux/*/active/modules/200/%{modulenames}
+%ghost %verify(not mode) %{_selinux_store_path}/targeted/active/modules/200/%{modulenames}
+%ghost %verify(not mode) %{_selinux_store_path}/mls/active/modules/200/%{modulenames}
 
 %triggerpostun -- container-selinux < 2:2.162.1-3
 if %{_sbindir}/selinuxenabled ; then

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,7 @@
 basic_check:
 	semodule --list=full | grep container
 	semodule -B
+	rpm -Vqf /var/lib/selinux/*/active/modules/200/container
 
 .PHONY: podman_e2e_test
 podman_e2e_test:


### PR DESCRIPTION
Wildcarding filepath in rpm files list doesn't seem to work as expected. This commit replaces wildcarded path with the exact path and also skips mode verification of the files installed in the ghosted path.

Also included is a test to check for file ownership in /var/lib/selinux.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2308833