### PR TITLE
Cleanup copr targets for packit, manage bats and golang deps idiomatically on TMT

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,10 +44,7 @@ jobs:
     enable_net: true
     # container-selinux is noarch so we only need to test on one arch
     targets: &fedora_copr_targets
-      - fedora-development
-      - fedora-latest
-      - fedora-ltest-stable
-      - fedora-40
+      - fedora-all
 
   - job: copr_build
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,9 +13,11 @@ files_to_sync:
   - src: plans/
     dest: plans/
     delete: true
+    mkpath: true
   - src: test/
     dest: test/
     delete: true
+    mkpath: true
   - src: .fmf/
     dest: .fmf/
     delete: true

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,6 +2,9 @@ discover:
     how: fmf
 execute:
     how: tmt
+prepare:
+    how: feature
+    epel: enabled
 
 /upstream:
     summary: Run SELinux specific Podman tests on upstream PRs

--- a/test/main.fmf
+++ b/test/main.fmf
@@ -1,7 +1,9 @@
 # Only common dependencies that are NOT required to run podman-tests.sh are
 # specified here. Everything else is in podman-tests.sh.
 require:
+    - bats
     - cpio
+    - golang
     - make
     - policycoreutils
 

--- a/test/podman-tests.sh
+++ b/test/podman-tests.sh
@@ -51,10 +51,6 @@ tar zxf *.tar.gz
 
 popd
 
-# Install dependencies for running tests
-# NOTE: bats will be fetched from Fedora repos on public testing-farm envs if EPEL repo is absent or disabled.
-dnf -y install bats golang
-
 # Print versions of distro and installed packages
 rpm -q bats container-selinux golang podman podman-tests selinux-policy
 


### PR DESCRIPTION
## Summary by Sourcery

Update the .packit.yaml configuration to streamline directory creation and consolidate Fedora targets. Remove redundant dependency installation from the podman-tests.sh script.

Build:
- Update the .packit.yaml configuration to include 'mkpath: true' for certain directories, ensuring they are created if they do not exist.

CI:
- Modify the .packit.yaml configuration to consolidate Fedora targets into a single 'fedora-all' target for copr builds.

Tests:
- Remove the installation of test dependencies 'bats' and 'golang' from the podman-tests.sh script, assuming they are available in the testing environment.