### PR TITLE
container_engine_t: allow access to user_tmp_t dir for ioctl

### DIFF
--- a/container.te
+++ b/container.te
@@ -1459,6 +1459,7 @@ allow container_engine_t zero_device_t:chr_file mounton;
 allow container_engine_t container_file_t:sock_file mounton;
 allow container_engine_t container_runtime_tmpfs_t:dir { ioctl list_dir_perms };
 allow container_engine_t devpts_t:chr_file setattr;
+allow container_engine_t user_tmp_t:dir ioctl;
 
 manage_chr_files_pattern(container_engine_t, fusefs_t, fusefs_t)
 


### PR DESCRIPTION
This change will grant `container_engine_t` the ability to perform `ioctl` operations on directories labeled user_tmp_t.

## Summary by Sourcery

Enhancements:
- Allow 'container_engine_t' to perform 'ioctl' operations on directories labeled 'user_tmp_t'.