### PR TITLE
RPM: Bump Epoch to 4

### DIFF
--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -30,7 +30,7 @@ Name: container-selinux
 %if %{defined copr_build}
 Epoch: 102
 %else
-Epoch: 2
+Epoch: 4
 %endif
 # Keep Version in upstream specfile at 0. It will be automatically set
 # to the correct value by Packit for copr and koji builds.


### PR DESCRIPTION
There was a recent container-selinux build on RHEL that required bumping the Epoch to 4. We should bump it here as well to preserve any future upgrade issues for cases like building from Packit and/or a future RHEL major version cut from Fedora.

## Summary by Sourcery

Build:
- Bump the Epoch value from 2 to 4 in the RPM spec file for container-selinux to align with recent changes in RHEL and prevent future upgrade issues.