### PR TITLE
rpm/gating.yaml: fix typo

### DIFF
--- a/rpm/gating.yaml
+++ b/rpm/gating.yaml
@@ -1,7 +1,7 @@
 --- !Policy
 product_versions:
   - fedora-*
-decision_context:
+decision_contexts:
   - bodhi_update_push_stable
   - bodhi_update_push_testing
 rules:


### PR DESCRIPTION
Koji builds don't work without this fix. Doesn't affect upstream, already fixed downstream.

## Summary by Sourcery

Bug Fixes:
- Fixes a typo in `gating.yaml` that prevents Koji builds from working.