### PR TITLE
Allow super privileged containers to use RealtimeKit for scheduling

### DIFF
--- a/container.te
+++ b/container.te
@@ -809,6 +809,10 @@ optional_policy(`
 ')
 
 optional_policy(`
+	rtkit_scheduled(spc_t)
+')
+
+optional_policy(`
 	virt_transition_svirt_sandbox(spc_t, system_r)
 	virt_sandbox_entrypoint(spc_t)
 	virt_sandbox_domtrans(container_runtime_domain, spc_t)


### PR DESCRIPTION
Toolbx containers are super privileged containers [1,2], because they use the host's cgroup, IPC, network and PID namespaces, and turn off SELinux label separation.  It's likely that users will want to use PipeWire inside Toolbx containers because they need some form of audio or video, and PipeWire needs to be able to use RealtimeKit to change the CPU priority of processes using these D-Bus interfaces:
  * `org.freedesktop.RealtimeKit1.MakeThreadHighPriorityWithPID`
  * `org.freedesktop.RealtimeKit1.MakeThreadRealtimeWithPID`

If the SELinux policy blocks the processes inside super privileged containers from using RealtimeKit, then it will lead to:
```
  type=AVC msg=audit(1721340769.363:269): avc:  denied  { setsched } for
      pid=762 comm="rtkit-daemon"
      scontext=system_u:system_r:rtkit_daemon_t:s0
      tcontext=unconfined_u:unconfined_r:spc_t:s0 tclass=process
      permissive=0
```

[1] https://developers.redhat.com/blog/2014/11/06/introducing-a-super-privileged-container-concept

[2] https://danwalsh.livejournal.com/74754.html

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2298800

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where SELinux policy blocks processes inside super privileged containers from using RealtimeKit.