### PR TITLE
Allow containers to mask parts of their /proc

### DIFF
--- a/container.te
+++ b/container.te
@@ -984,6 +984,7 @@ allow container_domain container_runtime_domain:socket_class_set { accept append
 
 kernel_getattr_proc(container_domain)
 kernel_list_all_proc(container_domain)
+kernel_mounton_all_proc(container_domain)
 kernel_read_all_sysctls(container_domain)
 kernel_dontaudit_write_kernel_sysctl(container_domain)
 kernel_read_network_state(container_domain)


### PR DESCRIPTION
Allow processes inside of a container to mount things onto parts of the /proc that they have in order to mask things which the container engine didn't for whatever reason.

The triggering case here is running a buildah container where the defaults now attempt to mask `/proc/interrupts` (per https://github.com/containers/common/pull/2375) under a version of podman where its defaults don't do that, or which has been run with `--security-opt=unmask=/proc/interrupts`, which generates this AVC denial:
```
type=AVC msg=audit(1743097355.949:9141): avc:  denied  { mounton } for  pid=969981 comm="memfd:buildah-c" path="/var/tmp/buildah3562861391/mnt/rootfs/proc/interrupts" dev="proc" ino=4026532021 scontext=system_u:system_r:container_t:s0:c142,c352 tcontext=system_u:object_r:proc_t:s0 tclass=file permissive=0
```

## Summary by Sourcery

Enhance container security policy to allow processes inside containers to mount over specific /proc filesystem entries that may not be masked by default

New Features:
- Enable containers to mask parts of /proc filesystem dynamically, providing more flexibility in container security configurations

Bug Fixes:
- Resolve SELinux AVC denial when containers attempt to mount over /proc/interrupts

Enhancements:
- Improve container runtime flexibility by allowing runtime-level /proc filesystem masking