### PR TITLE
RPM: empty placeholder check section to silence rpmlint

### DIFF
--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -111,6 +111,9 @@ fi
 %posttrans
 %selinux_relabel_post
 
+# Empty placeholder check to silence rpmlint
+%check
+
 #define license tag if not already defined
 %{!?_licensedir:%global license %doc}
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Added an empty placeholder check section to the container-selinux RPM spec file to comply with rpmlint requirements