### PR TITLE
Add lables for /var/kubernetes and /var/lib/kubernetes

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -131,6 +131,7 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /opt/local-path-provisioner(/.*)?		gen_context(system_u:object_r:container_file_t,s0)
 
 /var/lib/origin(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/kubernetes(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
 /var/lib/kubernetes/pods(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
 
 /var/lib/kubelet(/.*)?		gen_context(system_u:object_r:container_var_lib_t,s0)
@@ -170,3 +171,4 @@ HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:
 /var/log/lxc(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /var/log/lxd(/.*)?		gen_context(system_u:object_r:container_log_t,s0)
 /etc/kubernetes(/.*)?		gen_context(system_u:object_r:kubernetes_file_t,s0)
+/var/kubernetes(/.*)?		gen_context(system_u:object_r:kubernetes_file_t,s0)


### PR DESCRIPTION
Working with `bootc` and `transient.etc`, it is helpful to have some kubernetes elements in `/var` to create persistence.

## Summary by Sourcery

New Features:
- Create SELinux file context labels for /var/kubernetes and /var/lib/kubernetes directories