### PR TITLE
bootc/install_t: allow transition to container_runtime_t

### DIFF
--- a/container.te
+++ b/container.te
@@ -1616,6 +1616,8 @@ allow container_domain container_ro_file_t:file { entrypoint execmod execute exe
 allow container_domain container_var_lib_t:file entrypoint;
 allow container_domain fusefs_t:file { append create entrypoint execmod execute execute_no_trans getattr ioctl link lock map mounton open read rename setattr unlink watch watch_reads write };
 
+allow install_t container_runtime_t:process2 { nnp_transition nosuid_transition };
+
 corecmd_entrypoint_all_executables(container_kvm_t)
 allow svirt_sandbox_domain exec_type:file { entrypoint execute execute_no_trans getattr ioctl lock map open read };
 allow svirt_sandbox_domain mountpoint:file entrypoint;


### PR DESCRIPTION
Generation of bootc compatible disk images is done via the command:
```
sudo podman run --rm -it --privileged \
         --pull=newer \
         --security-opt label=type:unconfined_t \
         -v ./config.toml:/config.toml:ro \
         -v ./output:/output \
         -v /var/lib/containers/storage/:/var/lib/containers/storage/ \
         quay.io/centos-bootc/bootc-image-builder:latest \
         --type qcow2 \
         quay.io/centos-bootc/centos-bootc:stream9
```
Ref: https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#-examples

And this currently results in an apparently harmless AVC denial:
```
avc:  denied  { nnp_transition nosuid_transition } for  pid=40081 comm="bootc" \
        scontext=system_u:system_r:install_t:s0:c68,c235 \
        tcontext=system_u:system_r:container_runtime_t:s0:c68,c235 \
        tclass=process2 permissive=0
```

This commit adds allow rules for processes with install_t type, like bootc, to silence the AVCs.

Ref: https://issues.redhat.com/browse/RHEL-85671

## Summary by Sourcery

Bug Fixes:
- Resolve SELinux AVC denial when running bootc image builder with privileged container transitions