### PR TITLE
label /run/sysctl.d correctly on creation

### DIFF
--- a/container.te
+++ b/container.te
@@ -2,6 +2,7 @@ policy_module(container, 2.237.0)
 
 gen_require(`
 	class passwd rootok;
+	type system_conf_t;
 ')
 
 ########################################
@@ -1626,3 +1627,7 @@ tunable_policy(`deny_ptrace',`',`
 	allow container_domain self:process ptrace;
 	allow spc_t self:process ptrace;
 ')
+
+# netavark needs to write to /run/sysctl.d and needs the right label for systemd to read it.
+# https://issues.redhat.com/browse/RHEL-91380
+files_pid_filetrans(container_runtime_t, system_conf_t, dir, "sysctl.d")


### PR DESCRIPTION
As part of a netavark bug[1] fix I must create /run/sysctl.d to write some config files there for systemd. Howver in order for them to be able to get read by systemd-sysctl they must have the system_conf_t context.

As I don't want to add a manual relabel in netavark add a selinux file transition rule here because netavark runs as container_runtime_t.

[1] https://github.com/containers/netavark/pull/1245

## Summary by Sourcery

Add SELinux policy to label and transition /run/sysctl.d to system_conf_t when created by container_runtime_t

Enhancements:
- Add file context rule to label /run/sysctl.d as system_conf_t
- Add file transition rule from container_runtime_t to system_conf_t for /run/sysctl.d