### PR TITLE
BUmp to v2.238.0

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.237.0)
+policy_module(container, 2.238.0)
 
 gen_require(`
 	class passwd rootok;


### PR DESCRIPTION
## Summary by Sourcery

Bump the SELinux container policy to v2.238.0 and allow cgroup1_ro_t to read flashdrive-like filesystems under cgroup subtrees

Enhancements:
- Allow cgroup1_ro_t to perform getattr, open, search, and read on vfat and msdos types in cgroup1_ro cgroup mounts

Chores:
- Bump container policy module version to 2.238.0