### PR TITLE
Fix denial for rootless docker

### DIFF
--- a/container.te
+++ b/container.te
@@ -465,6 +465,7 @@ optional_policy(`
 	container_append_file(iptables_t)
 	allow iptables_t container_runtime_domain:fifo_file rw_fifo_file_perms;
 	allow iptables_t container_file_type:dir list_dir_perms;
+	dontaudit iptables_t self:cap_userns dac_override;
 ')
 
 optional_policy(`


### PR DESCRIPTION
I am seeing the following AVC with rootless docker and am looking for guidance how a better solution might look:

> type=AVC msg=audit(..): avc:  denied  { dac_override } for  pid=18028 comm="iptables" capability=1  scontext=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 tcontext=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 tclass=cap_userns permissive=0

Have the full auditing results with more details in the commit message.

The AVC occurs during:

> systemctl --user start docker.service

and needs as a per-requisite the `ip_tables` kernel module loaded to create `/proc/net/ip_tables_names`:

> modprobe ip_tables

Could see this for a SLES as well as a fedora workstation. Submitting the naive solution to get some feedback how best to solve this. 

*edit:* The team testing this reports no noticeable impact on the functionality tested, so maybe `dontaudit` instead?

## Summary by Sourcery

Update the SELinux container policy to permit iptables operations required for rootless Docker networking by granting the necessary capability and ensuring the ip_tables module can be loaded.

Enhancements:
- Grant CAP_DAC_OVERRIDE to iptables_t in container SELinux policy to allow rootless Docker to configure iptables
- Enable loading of the ip_tables kernel module for containerized environments