### PR TITLE
Allow domains that trans to container_runtime_t bpf:prog_run

### DIFF
--- a/container.if
+++ b/container.if
@@ -19,6 +19,7 @@ interface(`container_runtime_domtrans',`
 	corecmd_search_bin($1)
 	domtrans_pattern($1, container_runtime_exec_t, container_runtime_t)
 	allow container_runtime_t $1:fifo_file setattr;
+	allow $1 container_runtime_t:bpf prog_run;
 ')
 
 ########################################

--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.240.0)
+policy_module(container, 2.241.0)
 
 gen_require(`
 	class passwd rootok;
@@ -743,7 +743,7 @@ optional_policy(`
 	allow unconfined_domain_type { container_var_lib_t container_ro_file_t }:file entrypoint;
 	fs_fusefs_entrypoint(unconfined_domain_type)
 
-	domtrans_pattern(unconfined_domain_type, container_runtime_exec_t , container_runtime_t)
+	container_runtime_domtrans(unconfined_domain_type)
 ')
 
 optional_policy(`
@@ -1335,6 +1335,7 @@ container_manage_share_files(init_t)
 container_manage_share_dirs(init_t)
 container_filetrans_named_content(init_t)
 container_runtime_read_tmpfs_files(init_t)
+allow init_t container_runtime_t:bpf prog_run;
 
 gen_require(`
 	attribute device_node;


### PR DESCRIPTION
Fixes: https://github.com/containers/container-selinux/issues/389

## Summary by Sourcery

Bug Fixes:
- Grant bpf prog_run permission to container_runtime_t to fix BPF execution being blocked in containers