### PR TITLE
Allow container access to runtime directories for crun masked path optimization

### DIFF
--- a/container.te
+++ b/container.te
@@ -1348,6 +1348,9 @@ allow container_domain init_t:unix_stream_socket { accept ioctl read getattr loc
 
 allow container_t proc_t:filesystem remount;
 
+# Allow containers to access shared runtime directories for OCI runtime optimizations
+allow container_t container_var_run_t:dir { read open };
+
 # Container kvm - Policy for running kata containers
 container_domain_template(container_kvm, container)
 typeattribute container_kvm_t container_net_domain, container_user_domain;


### PR DESCRIPTION
Problem: crun PR #1859 (https://github.com/containers/crun/pull/1859) optimizes masked paths by using a shared empty directory instead of individual tmpfs mounts. However, containers cannot access this shared directory due to SELinux policy:
```
  avc: denied { read } for name=".empty-directory"
  scontext=container_t:s0:c139,c767 tcontext=container_var_run_t:s0
```
Without this policy, the optimization falls back to individual tmpfs mounts, negating the performance benefits.

## Summary by Sourcery

Bug Fixes:
- Grant container_t permission to read and search the shared .empty-directory under /run for masked path optimization