### PR TITLE
Allow containers to read TCP diagnostic info

### DIFF
--- a/container.te
+++ b/container.te
@@ -1121,6 +1121,7 @@ allow container_net_domain self:packet_socket create_socket_perms;
 allow container_net_domain self:socket create_socket_perms;
 allow container_net_domain self:rawip_socket create_stream_socket_perms;
 allow container_net_domain self:netlink_kobject_uevent_socket create_socket_perms;
+allow container_net_domain self:netlink_tcpdiag_socket nlmsg_read;
 allow container_net_domain self:netlink_xfrm_socket create_netlink_socket_perms;
 
 allow container_domain spc_t:unix_stream_socket { read write };

--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -20,14 +20,14 @@
 %define no_user_namespace 1
 %endif
 
-# copr_build is more intuitive than copr_username
-%if %{defined copr_username}
-%define copr_build 1
+# set copr_build is more intuitive than copr_username
+%if %{defined copr_username} && "%{copr_username}" == "rhcontainerbot" && "%{copr_projectname}" == "podman-next"
+%define next_build 1
 %endif
 
 Name: container-selinux
-# Set different Epochs for copr and koji
-%if %{defined copr_build}
+# Set different Epoch for rhcontainerbot/podman-next copr build
+%if %{defined next_build}
 Epoch: 102
 %else
 Epoch: 4


### PR DESCRIPTION
See individual commits. I'm also modifying the rpm spec a bit to ensure default Epoch is used for all copr builds except the one on rhcontainerbot/podman-next.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2392871

## Summary by Sourcery

Allow containers to read TCP diagnostic information by updating the SELinux policy and refine the RPM spec to use the default Epoch except for rhcontainerbot/podman-next builds.

New Features:
- Grant container processes permission to perform TCP socket diagnostics in the SELinux policy

Enhancements:
- Introduce a next_build condition in the RPM spec to set Epoch 102 only for rhcontainerbot/podman-next builds and default to Epoch 4 otherwise