### PR TITLE
Bump to v2.243.0

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.242.0)
+policy_module(container, 2.243.0)
 
 gen_require(`
 	class passwd rootok;


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update container.te to reflect SELinux policy version 2.243.0