### PR TITLE
Introduce container_write_proc_files interface (bsc#1253469)

### DIFF
--- a/container.if
+++ b/container.if
@@ -89,6 +89,25 @@ interface(`container_read_state',`
 
 ########################################
 ## <summary>
+##	Write to /proc/PID of container runtime.
+##	This is needed e.g. to set uid_map or gid_map
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_write_proc_files',`
+	gen_require(`
+		type container_runtime_t;
+	')
+
+	allow $1 container_runtime_t:file { open write };
+')
+
+########################################
+## <summary>
 ##	Search container lib directories.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
account-utils needs to write /proc/<pid_of_containers>/uid_map and gid_map.

We are currently working to confining three systemd services of account-utils in the openSUSE
policy (downstream of fedora policy) and this needs an interface from the container-selinux side.

Context:
- https://github.com/thkukuk/account-utils/blob/bf57c14f254570b4e5ad24925d8e481bff2ab828/src/newidmapd.c#L216
- https://www.thkukuk.de/blog/no_new_privs/

## Summary by Sourcery

New Features:
- Introduce a container_write_proc_files interface for writing uid_map and gid_map under /proc of container processes from account-utils-related services.