### PR TITLE
[backport rhaos-maint] v2.244.0

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.242.0)
+policy_module(container, 2.244.0)
 
 gen_require(`
 	class passwd rootok;


### PR DESCRIPTION
(cherry picked from commit ea03c39acffff751e7127a83dc343be037dc1aae)

No release cut from this branch. Only for older openshift builds.

## Summary by Sourcery

Backport changes for v2.244.0 into the rhaos-maint branch without introducing any functional modifications, aligning this branch with the referenced upstream commit for older OpenShift builds.