### PR TITLE
Add ~/.local/share/containers/storage/overlay-containers to .fc (bsc#…

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -100,6 +100,8 @@ HOME_DIR/\.local/share/containers/storage/overlay-layers(/.*)?	 gen_context(syst
 HOME_DIR/\.local/share/containers/storage/overlay2-layers(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
 HOME_DIR/\.local/share/containers/storage/overlay-images(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
 HOME_DIR/\.local/share/containers/storage/overlay2-images(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
+HOME_DIR/\.local/share/containers/storage/overlay-containers(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
+HOME_DIR/\.local/share/containers/storage/overlay2-containers(/.*)?	 gen_context(system_u:object_r:container_ro_file_t,s0)
 HOME_DIR/\.local/share/containers/storage/volumes/[^/]*/.*	gen_context(system_u:object_r:container_file_t,s0)
 
 /var/lib/containers(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)


### PR DESCRIPTION
…1253682)

For some reason it is not listed in the file contexts, so it will show up as to be relabelled when running "restorecon":

Would relabel /home/foo/.local/share/containers/storage/overlay-containers/f857f27662ab22b7c502a531d61790b7c120dbedc70820962bb45c285aa03cc3/userdata/artifacts from unconfined_u:object_r:container_ro_file_t:s0 to unconfined_u:object_r:data_home_t:s0 Would relabel /home/foo/.local/share/containers/storage/overlay-containers/2b562de7757133521824ac9de932ddd4862d8262695998a4ee02094c14fc1277/userdata/artifacts from unconfined_u:object_r:container_ro_file_t:s0 to unconfined_u:object_r:data_home_t:s0

<driver>-containers is defined here:
https://github.com/containers/storage/blame/83cf57466529353aced8f1803f2302698e0b5cb7/store.go#L3633

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect relabeling of ~/.local/share/containers/storage/overlay-containers paths by defining appropriate file contexts.