### PR TITLE
Allow container_runtime_domain runtime fifo_files transition

### DIFF
--- a/container.if
+++ b/container.if
@@ -418,6 +418,25 @@ interface(`container_read_pid_files',`
 
 ########################################
 ## <summary>
+##	Write container PID fifo files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`container_write_pid_fifo_files',`
+	gen_require(`
+		type container_var_run_t;
+	')
+
+	files_search_pids($1)
+	write_fifo_files_pattern($1, container_var_run_t, container_var_run_t)
+')
+
+########################################
+## <summary>
 ##	Execute container server in the container domain.
 ## </summary>
 ## <param name="domain">

--- a/container.te
+++ b/container.te
@@ -337,7 +337,7 @@ manage_fifo_files_pattern(container_runtime_domain, container_var_run_t, contain
 manage_sock_files_pattern(container_runtime_domain, container_var_run_t, container_var_run_t)
 manage_lnk_files_pattern(container_runtime_domain, container_var_run_t, container_var_run_t)
 files_pid_filetrans(container_runtime_domain, container_var_run_t, { dir file lnk_file sock_file })
-files_tmp_filetrans(container_runtime_domain, container_var_run_t, { dir file lnk_file sock_file })
+files_tmp_filetrans(container_runtime_domain, container_var_run_t, { dir fifo_file file lnk_file sock_file })
 allow container_runtime_domain container_var_run_t:dir_file_class_set relabelfrom;
 
 allow container_runtime_domain container_devpts_t:chr_file { relabelfrom rw_chr_file_perms setattr_chr_file_perms };


### PR DESCRIPTION
Seems to be triggered by
bats -t -f "podman kill - test signal handling in containers" test/system/130-kill.bats

The commit addresses the following AVC denial:
type=PROCTITLE msg=audit(03/17/25 12:12:47.095:1509) : proctitle=nft -j -f - type=EXECVE msg=audit(03/17/25 12:12:47.095:1509) : argc=4 a0=nft a1=-j a2=-f a3=- type=SYSCALL msg=audit(03/17/25 12:12:47.095:1509) : arch=x86_64 syscall=execve success=yes exit=0 a0=0x7f97e2882d70 a1=0x560887444100 a2=0x7ffdee1af598 a3=0x8 items=0 ppid=13726 pid=13733 auid=root uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=pts0 ses=16 comm=nft exe=/usr/sbin/nft subj=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 key=(null) type=AVC msg=audit(03/17/25 12:12:47.095:1509) : avc:  denied  { write } for pid=13733 comm=nft path=/tmp/podman_bats.vMhYNp/podman-kill-fifo.CMSpDDvE0M dev="xvda3 ino=377487601 scontext=unconfined_u:unconfined_r:iptables_t:s0-s0:c0.c1023 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=fifo_file permissive=0

Related: RHEL-83775

## Summary by Sourcery

Bug Fixes:
- Permit the container runtime domain to interact with temporary FIFO files to fix SELinux denials seen in podman kill signal-handling tests.