### PR TITLE
Allow TUN/TAP device access for container_engine_t

### DIFF
--- a/container.te
+++ b/container.te
@@ -1500,6 +1500,8 @@ kernel_mounton_systemd_ProtectKernelTunables(container_engine_t)
 term_mount_pty_fs(container_engine_t)
 term_use_generic_ptys(container_engine_t)
 
+corenet_rw_tun_tap_dev(container_engine_t)
+
 allow container_engine_t container_file_t:chr_file mounton;
 allow container_engine_t filesystem_type:{dir file} mounton;
 allow container_engine_t proc_kcore_t:file mounton;


### PR DESCRIPTION
OCP clusters upgraded from 4.17/4.18 to 4.20 get AVC denials for pasta operations in nested container mode.

Fixes: RHEL-131796

## Summary by Sourcery

Bug Fixes:
- Resolve SELinux AVC denials when performing pasta networking operations in nested container mode after upgrading OCP clusters from 4.17/4.18 to 4.20.