### PR TITLE
Fix amperasand in tunable comment

### DIFF
--- a/container.te
+++ b/container.te
@@ -86,7 +86,7 @@ gen_tunable(container_use_ecryptfs, false)
 ## <desc>
 ##  <p>
 ##  Allow containers to read shared public files
-##  (public_content_t & public_content_rw_t)
+##  (public_content_t &amp; public_content_rw_t)
 ##  </p>
 ## </desc>
 gen_tunable(container_read_public_content, false)


### PR DESCRIPTION
Contents of the comments are meant to be XML and plain & is not valid XML. See selinux-policy/support/segenxml.py https://github.com/fedora-selinux/selinux-policy/blob/rawhide/support/segenxml.py .

I have xmllint in my selinux-policy build env, but I guess default or test envs used in pipelines do not as I can not see how this issue can pass build otherwise.

https://github.com/fedora-selinux/selinux-policy/blob/415e98f61041ebd8158063d62e750cd391841e00/Makefile#L429-L431

Actual error, line number probably differs as there is unrelated other patches in setup.
```
doc/policy.xml:8390: parser error : xmlParseEntityRef: no name
(public_content_t & public_content_rw_t)
```

## Summary by Sourcery

Bug Fixes:
- Fix invalid XML in tunable comments by replacing raw ampersands with a valid XML-safe form.