### PR TITLE
Confined user fixes and bump to v2.247.0

### DIFF
--- a/container.te
+++ b/container.te
@@ -1343,6 +1343,12 @@ optional_policy(`
 
 	allow staff_t container_runtime_t:process signal_perms;
 	allow staff_t container_domain:process signal_perms;
+
+	# Allow confined user systemd instances to create and manage sockets
+	# for podman.socket activation (user-level systemd pre-labels the
+	# socket as container_runtime_t via setsockcreatecon)
+	allow { staff_t user_t } container_runtime_t:unix_stream_socket { create bind listen getattr setopt };
+
 	allow container_domain userdomain:socket_class_set { accept ioctl read getattr lock write append getopt shutdown setopt };
 ')
 

--- a/container.te
+++ b/container.te
@@ -99,6 +99,15 @@ gen_tunable(container_read_public_content, false)
 ## </desc>
 gen_tunable(container_manage_public_content, false)
 
+## <desc>
+##  <p>
+##  Allow user_t confined users to run podman containers.
+##  Disabled by default since user_t is the most restricted
+##  confined user type.
+##  </p>
+## </desc>
+gen_tunable(user_t_run_containers, false)
+
 attribute container_runtime_domain;
 container_runtime_domain_template(container_runtime)
 typealias container_runtime_t alias docker_t;
@@ -1336,10 +1345,11 @@ optional_policy(`
 	allow userdomain self:cap_userns ~{ sys_module };
 	container_read_state(userdomain)
 	allow userdomain container_runtime_t:process { noatsecure rlimitinh siginh };
-	container_runtime_run(user_t, user_r)
+	role user_r types container_runtime_t;
 	role user_r types container_user_domain;
 
 	staff_role_change_to(system_r)
+	unprivuser_role_change_to(system_r)
 
 	allow staff_t container_runtime_t:process signal_perms;
 	allow staff_t container_domain:process signal_perms;
@@ -1348,6 +1358,12 @@ optional_policy(`
 	# for podman.socket activation (user-level systemd pre-labels the
 	# socket as container_runtime_t via setsockcreatecon)
 	allow { staff_t user_t } container_runtime_t:unix_stream_socket { create bind listen getattr setopt };
+
+	tunable_policy(`user_t_run_containers',`
+		container_runtime_domtrans(user_t)
+		allow user_t container_runtime_t:process signal_perms;
+		allow user_t container_domain:process signal_perms;
+	')
 
 	allow container_domain userdomain:socket_class_set { accept ioctl read getattr lock write append getopt shutdown setopt };
 ')

--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.246.0)
+policy_module(container, 2.247.0)
 
 gen_require(`
 	class passwd rootok;

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -22,6 +22,10 @@ prepare:
         test: /test/basic_check
 
 /xmllint_validation:
+    enabled: false
+    adjust:
+        - when: initiator == packit
+          enabled: true
     discover+:
         test: /test/xmllint_validation
 


### PR DESCRIPTION
See individual commits.

## Summary by Sourcery

Update SELinux container policy and main plan configuration for confined user support and bump the project version to v2.247.0.

Bug Fixes:
- Adjust SELinux container policy to correctly handle confined user scenarios.

Enhancements:
- Refresh main plan configuration to align with updated confined user behavior and new version.

Build:
- Bump project version to v2.247.0 in build-related metadata.