### PR TITLE
Condition ptrace permission on deny_ptrace boolean

### DIFF
--- a/container.te
+++ b/container.te
@@ -207,7 +207,7 @@ mls_trusted_object(container_runtime_t)
 #
 allow container_runtime_domain self:capability { chown kill fowner fsetid mknod net_admin net_bind_service net_raw setfcap sys_resource };
 allow container_runtime_domain self:tun_socket { create_socket_perms relabelto };
-allow container_runtime_domain self:process ~setcurrent;
+allow container_runtime_domain self:process ~{ ptrace setcurrent };
 allow container_runtime_domain self:passwd rootok;
 allow container_runtime_domain self:fd use;
 allow container_runtime_domain self:dir mounton;
@@ -1702,6 +1702,7 @@ allow svirt_sandbox_domain mountpoint:file entrypoint;
 
 tunable_policy(`deny_ptrace',`',`
 	allow container_domain self:process ptrace;
+	allow container_runtime_domain self:process ptrace;
 	allow spc_t self:process ptrace;
 ')
 


### PR DESCRIPTION
The `ptrace` permission was conditioned on `deny_ptrace` being set to false everywhere in this policy except for `container_runtime_domain`. This applies the same policy to `container_runtime_domain`.

(This was an oversight in 9c85e0adc183afce81453622a834bf03a7811fcb.)

## Summary by Sourcery

Bug Fixes:
- Fix an oversight where ptrace permission in the container runtime domain was not gated by the deny_ptrace boolean like other domains.