### PR TITLE
[RHEL 8] Allow user_t and container_runtime_t to exchange dbus messages

### DIFF
--- a/container.te
+++ b/container.te
@@ -1363,6 +1363,8 @@ optional_policy(`
 		container_runtime_domtrans(user_t)
 		allow user_t container_runtime_t:process signal_perms;
 		allow user_t container_domain:process signal_perms;
+		allow user_t container_runtime_t:dbus send_msg;
+		allow container_runtime_t user_t:dbus send_msg;
 	')
 
 	allow container_domain userdomain:socket_class_set { accept ioctl read getattr lock write append getopt shutdown setopt };


### PR DESCRIPTION
When user_t runs rootless podman (which transitions to container_runtime_t), podman communicates with the systemd user session (user_t) via D-Bus to manage cgroups by calling StartTransientUnit.

Without this rule, systemd processes the request but SELinux blocks the D-Bus reply from user_t back to container_runtime_t. Podman then hangs indefinitely waiting for a response that never arrives. This denial doesn't show in the audit log as AVC because D-Bus access denials are handled by dbus-daemon itself, only visible via dbus-monitor as org.freedesktop.DBus.Error.AccessDenied:

```
error_name=org.freedesktop.DBus.Error.AccessDenied
"An SELinux policy prevents this sender from sending this message
to this recipient, 0 matched rules; type="method_return",
sender=":1.1" (uid=1001 pid=9877 comm="/usr/lib/systemd/systemd
--user " label="user_u:user_r:user_t:s0") interface="(unset)"
member="(unset)" error name="(unset)" requested_reply="0"
destination=":1.4" (uid=1001 pid=9917 comm="podman images "
label="user_u:user_r:container_runtime_t:s0")"
```

Add dbus send_msg rules between user_t and container_runtime_t inside the user_t_run_containers tunable to allow this communication.

This fix is specific to RHEL8 which uses `dbus-daemon` that enforces SELinux send_msg checks between peers. RHEL9+ and Fedora use `dbus-broker` which does not enforce peer-to-peer send_msg checks, so this rule is not needed there but is harmless.

## Summary by Sourcery

Bug Fixes:
- Resolve a hang in rootless Podman on RHEL 8 by allowing D-Bus replies between user_t and container_runtime_t under the user_t_run_containers tunable.