### PR TITLE
Allow rpmdb to manage files on mounted container filesystems

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.248.0)
+policy_module(container, 2.249.0)
 
 gen_require(`
 	class passwd rootok;

--- a/container.te
+++ b/container.te
@@ -1181,6 +1181,18 @@ optional_policy(`
 ')
 
 optional_policy(`
+	gen_require(`
+		type rpmdb_t, container_file_t;
+	')
+	domain_obj_id_change_exemption(rpmdb_t)
+	container_search_lib(rpmdb_t)
+	container_read_share_files(rpmdb_t)
+	container_manage_files(rpmdb_t)
+	container_manage_dirs(rpmdb_t)
+	allow rpmdb_t container_file_t:file map;
+')
+
+optional_policy(`
 	sssd_stream_connect(container_domain)
 ')
 


### PR DESCRIPTION
Running `rpmdb --rebuilddb --root=<container-mount-path>` on a mounted container filesystem fails with the following error when SELinux is enforcing:
```
 error: can't create transaction lock on .../merged/var/lib/rpm/.rpm.lock (Permission denied)
``` 

The AVC denial is:
```    
      avc: denied { search } for comm="rpmdb"
      scontext=unconfined_u:unconfined_r:rpmdb_t:s0-s0:c0.c1023
      tcontext=system_u:object_r:container_var_lib_t:s0 tclass=dir
```
   
The `rpmdb_t` domain needs access to:
- container_var_lib_t dirs (to traverse /var/lib/containers/storage/)
- container_ro_file_t dirs/files (to traverse overlay directories)
- container_file_t dirs/files (to manage RPM database in the merged fs)
    
Additionally, rpmdb_t needs the object identity change exemption to satisfy the UBAC constraint when creating files/dirs. Container filesystems are created by the container runtime with user identity system_u, but rpmdb is invoked from an unconfined user session (unconfined_u). Without the exemption, the user identity mismatch causes constraint violations on create operations. The map permission on container_file_t files is also needed for sqlite shared memory mapping during database operations.
    
Fixes: RHEL-58185

## Summary by Sourcery

Allow rpmdb to manage RPM databases on mounted container filesystems by updating SELinux policy for container storage paths and rpmdb_t.

Enhancements:
- Grant rpmdb_t access to container_var_lib_t, container_ro_file_t, and container_file_t to traverse and manage RPM databases on container filesystems.
- Add object identity change exemption for rpmdb_t to satisfy UBAC constraints when creating files and directories on container-managed storage.
- Permit rpmdb_t to use memory-mapped I/O (map permission) on container_file_t files for sqlite-based RPM database operations.