### PR TITLE
rpm: Require policycoreutils >= 3.10 for policydb version 24 support

### DIFF
--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -20,6 +20,11 @@
 %define no_user_namespace 1
 %endif
 
+# https://redhat.atlassian.net/browse/RHEL-151636
+%if %{defined rhel} && 0%{?rhel} <= 9
+%define old_policydb 1
+%endif
+
 # set copr_build is more intuitive than copr_username
 %if %{defined copr_username} && "%{copr_username}" == "rhcontainerbot" && "%{copr_projectname}" == "podman-next"
 %define next_build 1
@@ -52,7 +57,11 @@ Requires: selinux-policy >= %_selinux_policy_version
 Requires(post): selinux-policy-base >= %_selinux_policy_version
 Requires(post): selinux-policy-any >= %_selinux_policy_version
 Recommends: selinux-policy-targeted >= %_selinux_policy_version
+%if %{defined old_policydb}
 Requires(post): policycoreutils
+%else
+Requires(post): policycoreutils >= 3.10
+%endif
 Requires(post): libselinux-utils
 Requires(post): sed
 Obsoletes: %{name} <= 2:1.12.5-13

--- a/rpm/container-selinux.spec
+++ b/rpm/container-selinux.spec
@@ -20,6 +20,12 @@
 %define no_user_namespace 1
 %endif
 
+# https://redhat.atlassian.net/browse/RHEL-151636
+# RHEL <= 9 and Fedora <= 43 have older policydb versions
+%if (%{defined rhel} && 0%{?rhel} <= 9) || (%{defined fedora} && 0%{?fedora} <= 43)
+%define old_policydb 1
+%endif
+
 # set copr_build is more intuitive than copr_username
 %if %{defined copr_username} && "%{copr_username}" == "rhcontainerbot" && "%{copr_projectname}" == "podman-next"
 %define next_build 1
@@ -52,7 +58,11 @@ Requires: selinux-policy >= %_selinux_policy_version
 Requires(post): selinux-policy-base >= %_selinux_policy_version
 Requires(post): selinux-policy-any >= %_selinux_policy_version
 Recommends: selinux-policy-targeted >= %_selinux_policy_version
+%if %{defined old_policydb}
 Requires(post): policycoreutils
+%else
+Requires(post): policycoreutils >= 3.10
+%endif
 Requires(post): libselinux-utils
 Requires(post): sed
 Obsoletes: %{name} <= 2:1.12.5-13


### PR DESCRIPTION
The container-selinux %post script uses semodule to install policy modules. On CentOS Stream 10 / RHEL 10, the HLL/PP converter in policycoreutils < 3.10 doesn't support policydb module version 24, causing installation failures:

```
libsepol.policydb_read: policydb module version 24 does not match
my version range 4-23
```

policycoreutils 3.10 added support for version 24. This change adds a conditional requirement using the `old_policydb` macro for RHEL 9 and earlier, while RHEL 10+ and Fedora require >= 3.10.

Resolves: RHEL-151636

## Summary by Sourcery

Adjust container-selinux RPM dependencies to ensure compatibility with newer SELinux policy module versions on different RHEL and Fedora releases.

Build:
- Introduce an old_policydb macro to distinguish older RHEL/Fedora releases with legacy policydb versions.
- Conditionally require policycoreutils >= 3.10 in %post on newer RHEL/Fedora while retaining an unversioned dependency on older releases.