### PR TITLE
Add GitHub Action for xmllint validation

### DIFF
--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -1,0 +1,26 @@
+---
+
+name: "XML Validation"
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  xmllint-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Schedule tests on Testing Farm
+        uses: sclorg/testing-farm-as-github-action@v2
+        with:
+          api_key: ${{ secrets.TESTING_FARM_API_KEY }}
+          git_url: ${{ github.server_url }}/${{ github.repository }}
+          git_ref: ${{ github.ref }}
+          tmt_plan_regex: "xmllint_validation"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -23,10 +23,6 @@ prepare:
         test: /test/basic_check
 
 /xmllint_validation:
-    enabled: false
-    adjust:
-        - when: initiator == packit
-          enabled: true
     discover+:
         test: /test/xmllint_validation
 


### PR DESCRIPTION
Add workflow to run xmllint_validation TMT plan via Testing Farm. Enable the plan for GitHub Actions initiator.

## Summary by Sourcery

CI:
- Introduce a GitHub Actions workflow to trigger the xmllint_validation TMT plan via Testing Farm on pushes, pull requests, and manual runs targeting the main branch.