### PR TITLE
DO NOT MERGE

### DIFF
--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Schedule tests on Testing Farm
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TESTING_FARM_API_KEY }}
           git_url: ${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -3,7 +3,7 @@
 name: "XML Validation"
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   push:
     branches: [main]

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 ## Blogs on SELinux Policy
 
-**[Container Labeling](https://danwalsh.livejournal.com/81269.html)**  
+**[Container Labeling](https://danwalsh.livejournal.com/81269.html)**
 Explains `container_t` vs `container_var_lib_t`
 
-**[`container_t` versus `svirt_lxc_net_t`](https://danwalsh.livejournal.com/79191.html)**  
+**[`container_t` versus `svirt_lxc_net_t`](https://danwalsh.livejournal.com/79191.html)**
 Clarifys `container_t` versus `svirt_lxc_net_t` aliases
 
-**[SELinux, Podman, and Libvirt](https://danwalsh.livejournal.com/81143.html)**  
+**[SELinux, Podman, and Libvirt](https://danwalsh.livejournal.com/81143.html)**
 Information regarding SELinux blocking Podman container from talking to Libvirt
 
-**[Caution Relabeling Volumes with Container Runtimes](https://danwalsh.livejournal.com/76016.html)**  
+**[Caution Relabeling Volumes with Container Runtimes](https://danwalsh.livejournal.com/76016.html)**
 Explains effects of relabeling volumes with `:Z`
 
-**[Container Domains (Types)](https://danwalsh.livejournal.com/81756.html)**  
+**[Container Domains (Types)](https://danwalsh.livejournal.com/81756.html)**
 Explanation of SELinux Domain types.
 
-**[Containers and MLS](https://danwalsh.livejournal.com/77830.html)**  
-Container-selinux policy support of MLS (Multi Level Security).  
+**[Containers and MLS](https://danwalsh.livejournal.com/77830.html)**
+Container-selinux policy support of MLS (Multi Level Security).
+
+## DO NOT MERGE


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Normalize markdown formatting for the SELinux policy blog links in the README.