### PR TITLE
GHA: Update testing-farm action to use main branch

### DIFF
--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -3,7 +3,7 @@
 name: "XML Validation"
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   push:
     branches: [main]
@@ -13,14 +13,11 @@ jobs:
   xmllint-validation:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Schedule tests on Testing Farm
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TESTING_FARM_API_KEY }}
-          git_url: ${{ github.server_url }}/${{ github.repository }}
-          git_ref: ${{ github.ref }}
+          git_url: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}', github.server_url, github.repository) }}
+          git_ref: ${{ github.event.pull_request.head.sha || github.ref }}
           tmt_plan_regex: "xmllint_validation"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v2 was released quite sometime ago.
GHA: set trigger to pull_request_target

- Remove checkout step (Testing Farm clones the repo on VM)
- Use PR head repo/sha to test actual PR changes
- Fallback to base repo for push events
- Keeps secrets isolated from untrusted PR code

## Summary by Sourcery

Update XML validation workflow to run Testing Farm against pull request heads while keeping secrets isolated from untrusted code.

CI:
- Switch XML validation workflow trigger from pull_request to pull_request_target for safer secret handling.
- Update Testing Farm GitHub Action to track the main branch and remove the redundant checkout step.
- Configure Testing Farm job to use the PR head repo and commit for PR events, falling back to the base repository for push events.