### PR TITLE
GHA: Update testing-farm action to use main branch

### DIFF
--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -1,6 +1,6 @@
 ---
 
-name: "XML Validation"
+name: "Testing Farm Validation"
 
 on:
   pull_request_target:
@@ -9,15 +9,32 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  TF_GIT_URL: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}', github.server_url, github.repository) }}
+  TF_GIT_REF: ${{ github.event.pull_request.head.sha || github.ref }}
+
 jobs:
   xmllint-validation:
     runs-on: ubuntu-latest
     steps:
-      - name: Schedule tests on Testing Farm
+      - name: Schedule xmllint validation on Testing Farm
         uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TESTING_FARM_API_KEY }}
-          git_url: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}', github.server_url, github.repository) }}
-          git_ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          git_url: ${{ env.TF_GIT_URL }}
+          git_ref: ${{ env.TF_GIT_REF }}
           tmt_plan_regex: "xmllint_validation"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  basic-check:
+    runs-on: ubuntu-latest
+    needs: xmllint-validation
+    steps:
+      - name: Schedule basic check on Testing Farm
+        uses: sclorg/testing-farm-as-github-action@main
+        with:
+          api_key: ${{ secrets.TESTING_FARM_API_KEY }}
+          git_url: ${{ env.TF_GIT_URL }}
+          git_ref: ${{ env.TF_GIT_REF }}
+          tmt_plan_regex: "basic_check"
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/xmllint-validation.yml
+++ b/.github/workflows/xmllint-validation.yml
@@ -3,7 +3,7 @@
 name: "XML Validation"
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
   push:
     branches: [main]
@@ -13,14 +13,11 @@ jobs:
   xmllint-validation:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Schedule tests on Testing Farm
-        uses: sclorg/testing-farm-as-github-action@v2
+        uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TESTING_FARM_API_KEY }}
-          git_url: ${{ github.server_url }}/${{ github.repository }}
-          git_ref: ${{ github.ref }}
+          git_url: ${{ github.event.pull_request.head.repo.clone_url || format('{0}/{1}', github.server_url, github.repository) }}
+          git_ref: ${{ github.event.pull_request.head.sha || github.ref }}
           tmt_plan_regex: "xmllint_validation"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v2 was released quite sometime ago.
GHA: set trigger to pull_request_target

- Remove checkout step (Testing Farm clones the repo on VM)
- Use PR head repo/sha to test actual PR changes
- Fallback to base repo for push events
- Keeps secrets isolated from untrusted PR code

## Summary by Sourcery

Update the Testing Farm XML validation workflow to run on pull_request_target and use PR-specific sources while keeping secrets isolated from untrusted code.

CI:
- Switch the XML validation workflow trigger from pull_request to pull_request_target to improve security for PR runs.
- Update the Testing Farm GitHub Action to track the main branch and use PR head repository/commit with a fallback to the base repository for non-PR events.
- Remove the explicit checkout step from the XML validation workflow since the Testing Farm action clones the repository itself.