### PR TITLE
SECURITY.md: Use GitHub Security Advisory for reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,27 @@
 ## Security and Disclosure Information Policy for the container-selinux Project
 
-The container-selinux Project follows the [Security and Disclosure Information Policy](https://github.com/containers/container-libs/blob/main/SECURITY.md) for the Containers Projects.
+## Reporting Security Vulnerabilities
+
+If you discover a security vulnerability in container-selinux, please report it through GitHub's Security Advisory system. This allows us to coordinate a fix and disclosure process that protects users.
+
+Please DO NOT report the issue publicly via the GitHub issue tracker,
+mailing list, or Matrix.
+
+### How to Report
+
+1. Go to [our security advisory page](https://github.com/containers/container-selinux/security/advisories/new) to privately report the vulnerability.
+2. Provide detailed information about the vulnerability, including:
+   - Description of the issue
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if available)
+
+Your report will be reviewed by the maintainers, and we will work with you to understand and address the issue promptly.
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your vulnerability report within 48 hours.
+- **Updates**: We will keep you informed about our progress in addressing the vulnerability.
+- **Credit**: We will credit you for the discovery when we publish the fix (unless you prefer to remain anonymous).
+
+Thank you for helping keep container-selinux and its users secure!


### PR DESCRIPTION
Podman and other CNCF projects will soon be moving to another GitHub org so we can't continue to depend on SECURITY.md in container-libs.

Copied from containers/ramalama with modifications.

Fixes: #461

## Summary by Sourcery

Documentation:
- Add project-specific SECURITY.md instructions directing reporters to use GitHub Security Advisories for private vulnerability disclosure.