### PR TITLE
give container_domain perms on container_file_t fifo_files

### DIFF
--- a/container.if
+++ b/container.if
@@ -1000,6 +1000,7 @@ template(`container_manage_files_template',`
 	allow $1_t $2_file_t:chr_file { mmap_file_perms watch watch_reads };
 	manage_blk_files_pattern($1_t, $2_file_t, $2_file_t)
 	manage_fifo_files_pattern($1_t, $2_file_t, $2_file_t)
+	allow $1_t $2_file_t:fifo_file watch;
 	manage_sock_files_pattern($1_t, $2_file_t, $2_file_t)
 	allow $1_t $2_file_t:{file dir} mounton;
 	allow $1_t $2_file_t:filesystem { mount remount unmount };

--- a/container.te
+++ b/container.te
@@ -967,6 +967,7 @@ allow container_domain self:file rw_file_perms;
 allow container_domain self:lnk_file read_file_perms;
 allow container_domain self:fifo_file create_fifo_file_perms;
 allow container_domain self:fifo_file watch;
+allow container_domain container_file_t:fifo_file watch;
 allow container_domain self:filesystem associate;
 allow container_domain self:key manage_key_perms;
 allow container_domain self:netlink_route_socket r_netlink_socket_perms;


### PR DESCRIPTION
## Summary by Sourcery

Adjust container SELinux policy to grant container_domain permissions on fifo files labeled container_file_t.