### PR TITLE
Suppress mmap_zero denials for container_runtime_t

### DIFF
--- a/container.te
+++ b/container.te
@@ -213,6 +213,9 @@ allow container_runtime_domain self:fd use;
 allow container_runtime_domain self:dir mounton;
 allow container_runtime_domain self:file mounton;
 
+# Suppress mmap_zero denials for docker-ce's check utility
+dontaudit container_runtime_t self:memprotect mmap_zero;
+
 allow container_runtime_domain self:fifo_file rw_fifo_file_perms;
 allow container_runtime_domain self:fifo_file manage_file_perms;
 allow container_runtime_domain self:msg all_msg_perms;


### PR DESCRIPTION
Docker's check utility attempts to map low memory addresses during startup, triggering mmap_zero denials:

  avc: denied { mmap_zero } for comm="check"
  scontext=system_u:system_r:container_runtime_t:s0
  tcontext=system_u:system_r:container_runtime_t:s0 tclass=memprotect

A conditional allow rule exists but requires the mmap_low_allowed boolean (off by default). The operation is denied but doesn't break functionality - it just generates noisy audit logs.

Add dontaudit rule to suppress the denials, matching the existing fix for spc_t from rhbz#2297712 (commit af5a09c).

Fixes: rhbz#2458576

## Summary by Sourcery

Bug Fixes:
- Silence benign SELinux mmap_zero denials for container_runtime_t processes to reduce noise in audit logs.