### PR TITLE
Allow spc_t execstack and execmem (bsc#1268490)

### DIFF
--- a/container.te
+++ b/container.te
@@ -12,6 +12,13 @@ gen_require(`
 
 ## <desc>
 ##  <p>
+##  Allow container to make its stack executable
+##  </p>
+## </desc>
+gen_tunable(container_can_execstack, false)
+
+## <desc>
+##  <p>
 ##  Determine whether container can
 ##  connect to all TCP ports.
 ##  </p>
@@ -805,6 +812,10 @@ tunable_policy(`container_connect_any',`
 # spc local policy
 #
 allow spc_t { container_file_t container_var_lib_t container_ro_file_t container_runtime_tmpfs_t}:file entrypoint;
+allow spc_t self:process execmem;
+tunable_policy(`container_can_execstack',`
+	allow spc_t self:process execstack;
+')
 role system_r types spc_t;
 dontaudit spc_t self:memprotect mmap_zero;
 


### PR DESCRIPTION
This commit moved spc_t out of the container_domain: "Tighten controls on confined users"
https://github.com/containers/container-selinux/commit/236104789358a0c54576d2b742d45735c7402506

The container_domain lists execmem and execstack explicitly: https://github.com/containers/container-selinux/blob/f786136f58c4e1b7568f30463a44b050d0d84325/container.te#L1127

Now it is in unconfined_domain:
https://github.com/containers/container-selinux/blob/f786136f58c4e1b7568f30463a44b050d0d84325/container.te#L852C2-L852C27

execmem and execstack are allowed for unconfined_domain in fedora, but not openSUSE.
Since containers (especially java application containers) need those pretty often, lets allow that explicitly for spc_t again.

## Summary by Sourcery

Enhancements:
- Align spc_t SELinux policy with container needs by explicitly permitting execmem and execstack in the openSUSE policy variant.