### PR TITLE
Add container_runtime_nnp_domtrans interface for systemd-managed containers

### DIFF
--- a/container.if
+++ b/container.if
@@ -1127,3 +1127,23 @@ interface(`container_signull',`
 
         allow $1 container_t:process signull;
 ')
+
+########################################
+## <summary>
+##	Execute container_runtime in the container_runtime domain, 
+##	and allow the transition under NoNewPrivileges (NNP) or nosuid.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`container_runtime_nnp_domtrans',`
+	gen_require(`
+		type container_runtime_t;
+	')
+
+	container_runtime_domtrans($1)
+	allow $1 container_runtime_t:process2 { nnp_transition nosuid_transition };
+')


### PR DESCRIPTION
### Description
This PR introduces a new interface, `container_runtime_nnp_domtrans`, to allow caller domains to transition to the container runtime domain under `NoNewPrivileges` (NNP) and from `nosuid` mounts.

### Why is this needed?
When running Podman containers via systemd (specifically using Podman Quadlets), administrators often use standard systemd security directives like `DynamicUser=yes` or `ProtectSystem=strict`. Systemd automatically enables `NoNewPrivileges=yes` on the service process when these are used.

Because of this, the kernel blocks the SELinux domain transition into `container_runtime_t`, logging a `tclass=process2` denial for `nnp_transition` (and often `nosuid_transition`), causing the container to fail at startup. 

Currently, there is no interface exposed for caller domains to explicitly allow this transition under NNP.

### What this PR does
It adds the `container_runtime_nnp_domtrans` interface to `container.if`. 

By exposing this interface, we allow other policies (like the base OS policy) to consume it without breaking encapsulation. I plan to submit a follow-up PR to `fedora-selinux/selinux-policy` that uses this new interface to explicitly allow `unconfined_service_t` to spawn containers securely under NNP.

### Related Issues
https://bugzilla.redhat.com/show_bug.cgi?id=2417297

## Summary by Sourcery

Introduce a new SELinux interface to support domain transitions into the container runtime under NoNewPrivileges and nosuid constraints.

New Features:
- Add the container_runtime_nnp_domtrans SELinux policy interface for systemd-managed container runtimes operating under NoNewPrivileges and nosuid mounts.

Enhancements:
- Expose the new domain transition interface in container.if to allow external policies to grant secure transitions into container_runtime_t without breaking encapsulation.