### PR TITLE
Add the container_spc_signull() interface

### DIFF
--- a/container.if
+++ b/container.if
@@ -1029,6 +1029,24 @@ interface(`container_spc_rw_pipes',`
 
 ########################################
 ## <summary>
+##	Send null signals to spc container.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access
+##	</summary>
+## </param>
+#
+interface(`container_spc_signull',`
+	gen_require(`
+		type spc_t;
+	')
+
+	allow $1 spc_t:process signull;
+')
+
+########################################
+## <summary>
 ##	Execute container in the container domain.
 ## </summary>
 ## <param name="domain">


### PR DESCRIPTION
When coredump forwarding (CoredumpReceive) is enabled, systemd-coredump checks if the container leader is alive and listens on the coredump socket. This is needed for all container types.

## Summary by Sourcery

New Features:
- Add a container_spc_signull() interface to support liveness checks for containers using coredump forwarding.