### PR TITLE
Bump to v2.250.0

### DIFF
--- a/container.te
+++ b/container.te
@@ -1,4 +1,4 @@
-policy_module(container, 2.249.0)
+policy_module(container, 2.250.0)
 
 gen_require(`
 	class passwd rootok;


### PR DESCRIPTION
## Summary by Sourcery

Bump container policy module to version v2.250.0 with corresponding updates in container.te.