### PR TITLE
fix: Add missing contexts for Docker's containerd-snapshotter

### DIFF
--- a/container.fc
+++ b/container.fc
@@ -81,6 +81,9 @@
 /var/lib/docker/init(/.*)?		gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker/overlay(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 /var/lib/docker/overlay2(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
+# For Docker's embedded/supervised containerd instance.
+/var/lib/docker/containerd/daemon/[^/]*/snapshots(/.*)?	gen_context(system_u:object_r:container_file_t,s0)
+/var/lib/docker/containerd/daemon/[^/]*/sandboxes(/.*)?	gen_context(system_u:object_r:container_ro_file_t,s0)
 
 /var/lib/containerd(/.*)?	gen_context(system_u:object_r:container_var_lib_t,s0)
 # The "snapshots" directory of containerd and BuildKit must be writable, as it is used as an upperdir as well as a lowerdir.


### PR DESCRIPTION
On openSUSE, containers fail to start under SELinux enforcing with AVC denials on every binary inside any image, regardless of which image is used.

Root cause:
When a docker.service is configured to start without `--containerd=<socket>` flag it doesn't bind to containerd.service. Per dockerd's default behavior, dockerd falls back to spawning and supervising its own private containerd subprocess, storing snapshotter data under `/var/lib/docker/containerd/daemon/` instead of the standalone system containerd's `/var/lib/containerd/`.

Compare [SUSE](https://build.opensuse.org/package/view_file/openSUSE:Factory/docker-stable/docker.service) vs [Moby](https://github.com/moby/moby/blob/master/contrib/init/systemd/docker.service) services.

The current container.fc only has rules for the latter path, so the former falls through to the generic `/var/lib/docker(/.*)?` catch-all `(container_var_lib_t)`, which is not readable/executable by container_domain.

When a system with this kind of setup is fully relabeled or you migrate docker to another storage driver with snapshotter, it can corrupt the labels inside `/var/lib/docker/containerd/daemon/`, and the system ends flooded with a ton of rare AVC's trying to start/restart the containers.

The workarounds to fix this:

1. Turn SELinux to permissive mode.
2. Disable SELinux security on containers/compose files
3. Set the correct contexts, relabel, and make these permanent before starting again the docker engine.

I'll attach some AVC's, the docker compose file used to debug, and the docker daemon configuration.
[AVCs.txt](https://github.com/user-attachments/files/30142672/AVCs.txt)
[docker-compose.txt](https://github.com/user-attachments/files/30142675/docker-compose.txt)
[daemon.json](https://github.com/user-attachments/files/30142679/daemon.json)


References


- https://github.com/moby/moby/blob/11ee7e07df4203b65b9cb23302aed9f8d81af0b6/daemon/command/daemon.go#L1162 (default embedded-containerd behavior)
- https://docs.docker.com/engine/storage/containerd/ (containerd-snapshotter feature, default on Engine 29+)
- https://github.com/moby/moby/blob/master/contrib/init/systemd/docker.service (upstream unit, --containerd + BindsTo=containerd.service)
- https://build.opensuse.org/package/view_file/openSUSE:Factory/docker-stable/docker.service (openSUSE unit, no --containerd)
- https://github.com/containers/container-selinux/blob/main/container.fc (current policy, existing standalone-containerd rules used as the template for this patch)
- https://github.com/k3s-io/k3s-selinux/issues/34 Related/precedent bug class (non-standard containerd data-root not covered by generic .fc rules): k3s-selinux issue requiring explicit fcontext additions for a custom containerd data-root.

## Summary by Sourcery

Bug Fixes:
- Fix container start failures under SELinux enforcing on systems where Docker uses an embedded containerd with snapshotter data under /var/lib/docker/containerd/daemon/.