### PR TITLE
Allow sshd_session_t to launch containers

### DIFF
--- a/container.te
+++ b/container.te
@@ -1691,6 +1691,17 @@ tunable_policy(`sshd_launch_containers',`
 	dontaudit systemd_logind_t iptables_var_run_t:dir read;
 ')
 
+# OpenSSH 9.8+ split sshd into sshd (listener) + sshd-session (post-auth).
+# Forwarding now runs as sshd_session_t instead of sshd_t.
+optional_policy(`
+	tunable_policy(`sshd_launch_containers',`
+		gen_require(`
+			type sshd_session_t;
+		')
+		container_runtime_domtrans(sshd_session_t)
+	')
+')
+
 role container_user_r;
 userdom_restricted_user_template(container_user)
 userdom_manage_home_role(container_user_r, container_user_t)

--- a/test/main.fmf
+++ b/test/main.fmf
@@ -36,6 +36,6 @@ recommend:
         - when: distro == centos-stream
           environment+:
             ROOTLESS_USER: "ec2-user"
-        - when: distro == rhel
+        - when: distro == rhel or distro == fedora-eln
           environment+:
             ROOTLESS_USER: "cloud-user"


### PR DESCRIPTION
OpenSSH 9.8+ split sshd into sshd (listener) + sshd-session (post-auth session handling). All forwarding now runs as sshd_session_t instead of sshd_t. Extend the sshd_launch_containers boolean to cover sshd_session_t so SSH -L forwarding to container runtime sockets is not denied by SELinux.

Wrapped in optional_policy so it compiles on systems without the sshd-session split (OpenSSH < 9.8).

Fixes: https://github.com/containers/container-selinux/issues/478

## Summary by Sourcery

Extend SELinux container policy so sshd_session_t can launch containers when the sshd_launch_containers boolean is enabled, while preserving compatibility with OpenSSH versions without sshd-session.

Bug Fixes:
- Allow SSH local forwarding to container runtime sockets to work under SELinux on systems using the split sshd/sshd-session model in OpenSSH 9.8+.

Enhancements:
- Generalize the sshd_launch_containers SELinux boolean to cover both sshd_t and sshd_session_t using optional policy so it builds on systems without sshd-session.