### PR TITLE
tmt: Use cloud-user for Fedora ELN rootless tests

### DIFF
--- a/test/main.fmf
+++ b/test/main.fmf
@@ -36,6 +36,6 @@ recommend:
         - when: distro == centos-stream
           environment+:
             ROOTLESS_USER: "ec2-user"
-        - when: distro == rhel
+        - when: distro == rhel or distro == fedora-eln
           environment+:
             ROOTLESS_USER: "cloud-user"


### PR DESCRIPTION
Fedora ELN Testing Farm instances use cloud-user (UID 1000) as the default user, not fedora. This causes rootless podman tests to fail with "fedora user not found" errors.

Combine the RHEL and Fedora ELN adjust rules since both use cloud-user for rootless testing.

Fixes rootless test failures on Fedora ELN compose in Testing Farm.

## Summary by Sourcery

Update Fedora ELN rootless test configuration to use the cloud-user account, aligning it with RHEL rootless testing behavior and resolving user-not-found failures.

Bug Fixes:
- Resolve rootless podman test failures on Fedora ELN Testing Farm instances caused by referencing a non-existent fedora user.

Enhancements:
- Unify RHEL and Fedora ELN test adjustments so both use the cloud-user account for rootless testing.