### PR TITLE
fix: Allow spc_t permissions for container_runtime_domain directory management

### DIFF
--- a/container.te
+++ b/container.te
@@ -830,6 +830,7 @@ allow spc_t container_file_type:file execmod;
 admin_pattern(spc_t, kubernetes_file_t)
 
 allow spc_t container_runtime_domain:fifo_file manage_fifo_file_perms;
+manage_dirs_pattern(spc_t, container_runtime_domain, container_runtime_domain)
 allow spc_t { container_ro_file_t container_file_t }:system module_load;
 
 allow container_runtime_domain spc_t:process { dyntransition setsched signal_perms };


### PR DESCRIPTION
## Problem

Privileged containers (spc_t) that inspect or manage their own
`/proc/<pid>/fd` directory generate an AVC denial when that
directory is labeled with a container_runtime_domain type
(e.g. container_runtime_t) instead of proc_t:

```
sudo ausearch -m avc -ts recent -c run-document-se
----
time->Thu Jul 23 15:10:31 2026
type=AVC msg=audit(1784841031.153:9931): avc:  denied  { write } for  pid=4040299 comm="run-document-se" name="fd" dev="proc" ino=34722895 scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:container_runtime_t:s0 tclass=dir permissive=1
----
time->Thu Jul 23 15:10:31 2026
type=AVC msg=audit(1784841031.153:9932): avc:  denied  { add_name } for  pid=4040299 comm="run-document-se" name="1" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:system_r:container_runtime_t:s0 tclass=dir permissive=1
```

Reported downstream in ONLYOFFICE/Docker-DocumentServer#855 and [SUSE Bugzilla](https://bugzilla.suse.com/show_bug.cgi?id=1261545), reproduced
on openSUSE Leap 16.0 (selinux-policy-targeted 20250627,
container-selinux 2.239.0) with dockerd/containerd-shim. Occurs on
every container start/restart, even with `security_opt: label=disabled`
in some runtime configs where the container is still assigned spc_t.

This is not specific to one runtime implementation: any engine whose
shim/daemon process is labeled with a type under container_runtime_domain
(dockerd, containerd-shim, crun, CRI-O, etc.) can trigger the same
denial, since it depends on which process owns the parent /proc entry
being inspected, not on the container engine itself.

## Fix

Add a minimal `allow` rule scoped to `dir { add_name write }`, targeting
the container_runtime_domain attribute rather than the concrete
container_runtime_t type, so the fix covers all runtime engines under
that attribute rather than only the one observed in this report. This
mirrors the existing symmetric rule already in container.te:

    allow container_runtime_domain spc_t:socket_class_set { relabelto relabelfrom };

and follows the extensibility rationale discussed in #78 for using
container_runtime_domain over container_runtime_t in spc_t-related
rules. The permission set stays minimal and specific (add_name, write
on dir only), consistent with the narrower-scope precedent set by #138
over #137.

## Testing

Verified locally with `audit2allow` against the reported AVCs; no
further denials observed after applying the equivalent local module.

## Summary by Sourcery

Bug Fixes:
- Grant spc_t minimal dir write and add_name permissions on container_runtime_domain-labeled /proc fd directories to eliminate recurring AVC denials across container runtimes.